### PR TITLE
Don't buffer SyncTimer for Controllers

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncTimer.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncTimer.cs
@@ -81,9 +81,6 @@ namespace PurrNet
         [TargetRpc]
         private void BufferPlayer([UsedImplicitly] PlayerID player, float timeRemaining, TimerState state)
         {
-            if (isServer)
-                return;
-
             _remaining = timeRemaining;
             _state = state;
         }

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncTimer.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncTimer.cs
@@ -81,6 +81,9 @@ namespace PurrNet
         [TargetRpc]
         private void BufferPlayer([UsedImplicitly] PlayerID player, float timeRemaining, TimerState state)
         {
+            if (IsController(_ownerAuth))
+                return;
+
             _remaining = timeRemaining;
             _state = state;
         }

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncTimer.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncTimer.cs
@@ -81,6 +81,9 @@ namespace PurrNet
         [TargetRpc]
         private void BufferPlayer([UsedImplicitly] PlayerID player, float timeRemaining, TimerState state)
         {
+            if (isServer)
+                return;
+
             _remaining = timeRemaining;
             _state = state;
         }


### PR DESCRIPTION
When a SyncTimer is on a `StateNode` and `StartTimer()` is called from `Enter()`, there is a race condition where the `BufferPlayer()` call is received after with the previous state (Stopped), causing the timer to stop right after starting.

Since the Controller should get updates right away, we can ignore them in `BufferPlayer()`.