### PR TITLE
chore: rename Purrnet Test aseembly

### DIFF
--- a/Assets/PurrNet/Tests/Tests.asmdef
+++ b/Assets/PurrNet/Tests/Tests.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Tests",
+    "name": "Purrnet.Tests",
     "rootNamespace": "Purrnet.Tests",
     "references": [
         "UnityEngine.TestRunner",


### PR DESCRIPTION
The test assembly has a very generic name "Tests". 
This is just a clean up  to change the name to prevent conflicts with other badly named assemblies.