### PR TITLE
Steam Transport SendToClient safety checks addition

### DIFF
--- a/Assets/PurrNet/Addons/Steam/Runtime/SteamTransport.cs
+++ b/Assets/PurrNet/Addons/Steam/Runtime/SteamTransport.cs
@@ -220,6 +220,12 @@ namespace PurrNet.Steam
 
         public void SendToClient(Connection target, ByteData data, Channel method = Channel.ReliableOrdered)
         {
+            if (listenerState is not ConnectionState.Connected)
+                return;
+            
+            if (!target.isValid)
+                return;
+
             _server.SendToConnection(target.connectionId, data, method);
         }
 


### PR DESCRIPTION
When shutting a server down with network objects, the cleanup process throws an error with the Steam transport:
```
NullReferenceException: Object reference not set to an instance of an object
PurrNet.Steam.SteamTransport.SendToClient (PurrNet.Transports.Connection target, PurrNet.Transports.ByteData data, PurrNet.Transports.Channel method) (at ./Library/PackageCache/purrnet/Addons/Steam/Runtime/SteamTransport.cs:225)
PurrNet.Modules.BroadcastModule.Send[T] (PurrNet.Transports.Connection conn, T data, PurrNet.Transports.Channel method) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/Broadcast/BroadcastModule.cs:113)
PurrNet.PlayersBroadcaster.Send[T] (PurrNet.PlayerID player, T data, PurrNet.Transports.Channel method) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/Players/PlayersBroadcaster.cs:143)
PurrNet.Modules.PlayersManager.Send[T] (PurrNet.PlayerID player, T data, PurrNet.Transports.Channel method) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/Players/PlayersManager.cs:132)
PurrNet.Modules.HierarchyV2.SendDespawnPacket (PurrNet.PlayerID player, PurrNet.NetworkIdentity identity) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:583)
PurrNet.Modules.HierarchyV2.OnVisibilityChanged (PurrNet.PlayerID player, UnityEngine.Transform scope, System.Boolean isVisible) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:566)
PurrNet.Modules.VisilityV2.ClearVisibilityForGameObject (UnityEngine.Transform transform) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/HierarchyV2/VisilityV2.cs:55)
PurrNet.Modules.HierarchyV2.Despawn (UnityEngine.GameObject gameObject, System.Boolean bypassPermissions) (at ./Library/PackageCache/purrnet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:744)
PurrNet.Modules.HierarchyV2.Cleanup () (at ./Library/PackageCache/purrnet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:194)
PurrNet.Modules.HierarchyFactory.Cleanup () (at ./Library/PackageCache/purrnet/Runtime/CoreModules/HierarchyV2/HierarchyFactory.cs:153)
PurrNet.ModulesCollection.Cleanup () (at ./Library/PackageCache/purrnet/Runtime/Managers/ModulesCollection.cs:126)
PurrNet.NetworkManager.FixedUpdate () (at ./Library/PackageCache/purrnet/Runtime/Managers/NetworkManager.cs:878)
```

It seems that the execution order is identical on UDP / Local / Steam, but it seems they have more checks in place vs the Steam transport, which I am not sure is intentional:

UDP:
```csharp
public void SendToClient(Connection target, ByteData data, Channel method = Channel.Unreliable)
{
    if (listenerState is not ConnectionState.Connected)
        return;
    
    if (!target.isValid)
        return;
    
    var deliveryMethod = ToDeliveryMethod(method);
    var peer = _server.GetPeerById(target.connectionId);
    peer?.Send(data.data, data.offset, data.length, deliveryMethod);
    RaiseDataSent(target, data, true);
}
```

Local:
```csharp
public void SendToClient(Connection target, ByteData data, Channel method = Channel.Unreliable)
{
    if (clientState != ConnectionState.Connected ||
        listenerState != ConnectionState.Connected)
        return;
    
    QueuePacket(data, false);
    // onDataReceived?.Invoke(default, data, false);
    RaiseDataSent(target, data, true);
}
```
 
Steam:
 ```csharp
public void SendToClient(Connection target, ByteData data, Channel method = Channel.ReliableOrdered)
{
    _server.SendToConnection(target.connectionId, data, method);
}
```

UDP:
![UDP](https://github.com/user-attachments/assets/cd50431e-c025-4c1c-a3ec-1f4536ad3183)

Steam:
![Steam](https://github.com/user-attachments/assets/82284ee3-fb57-473a-aa45-c13f7ed2b6bb)
