### PR TITLE
Null check rootObject inside of SceneObjectsModule.cs

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneObjectsModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/SceneObjectsModule.cs
@@ -39,7 +39,7 @@ namespace PurrNet.Modules
             
             foreach (var rootObject in rootGameObjects)
             {
-                if (rootObject.scene.handle != scene.handle) continue;
+                if (rootObject == null || rootObject.scene.handle != scene.handle) continue;
                 
                 rootObject.gameObject.GetComponentsInChildren(true, _sceneIdentities);
                 


### PR DESCRIPTION
Seeing a weird behavior specifically in builds where `rootObject` is null on the second time hosting.

In my main menu scene, I have a scene network object to just hold some data that is `dontdestroyonload`.

The steps to repro go something like:
1. Start Client -> Enter Lobby Scene
2. Stop Client -> Enter Main Menu Scene
3. Start Client -> Enter Lobby Scene (throws error with `rootObject` being null`

I don't believe this fix is more than a bandaid fix, but it seems to handle the problem on my end for now!

```
NullReferenceException: Object reference not set to an instance of an object.
  at UnityEngine.Bindings.ThrowHelper.ThrowNullReferenceException (System.Object obj) [0x00018] in C:\build\output\unity\unity\Runtime\Export\Scripting\BindingsHelpers.cs:62 
  at UnityEngine.GameObject.get_scene () [0x00006] in <15cf5152f2b34266b6c1139f812ce4fd>:0 
  at PurrNet.Modules.SceneObjectsModule.GetSceneIdentities (UnityEngine.SceneManagement.Scene scene, System.Collections.Generic.List`1[T] networkIdentities) [0x000a7] in .\Library\PackageCache\purrnet\Runtime\CoreModules\Scenes\SceneObjectsModule.cs:42 
  at PurrNet.Modules.HierarchyV2.SetupSceneObjects (UnityEngine.SceneManagement.Scene scene) [0x0006e] in .\Library\PackageCache\purrnet\Runtime\CoreModules\HierarchyV2\HierarchyV2.cs:82 
  at PurrNet.Modules.HierarchyV2..ctor (PurrNet.NetworkManager manager, PurrNet.SceneID sceneId, UnityEngine.SceneManagement.Scene scene, PurrNet.Modules.ScenePlayersModule players, PurrNet.Modules.PlayersManager playersManager, System.Boolean asServer) [0x000b7] in .\Library\PackageCache\purrnet\Runtime\CoreModules\HierarchyV2\HierarchyV2.cs:59 
  at PurrNet.Modules.HierarchyFactory.OnPreSceneLoaded (PurrNet.SceneID scene, System.Boolean asServer) [0x0007e] in .\Library\PackageCache\purrnet\Runtime\CoreModules\HierarchyV2\HierarchyFactory.cs:76 
  at PurrNet.Modules.HierarchyFactory.Enable (System.Boolean asServer) [0x00047] in .\Library\PackageCache\purrnet\Runtime\CoreModules\HierarchyV2\HierarchyFactory.cs:46 
  at PurrNet.ModulesCollection.RegisterModules () [0x00028] in .\Library\PackageCache\purrnet\Runtime\Managers\ModulesCollection.cs:62 
  at PurrNet.NetworkManager.InternalRegisterServerModules () [0x00008] in .\Library\PackageCache\purrnet\Runtime\Managers\NetworkManager.cs:1025 
  at PurrNet.Transports.GenericTransport.StartServer (PurrNet.NetworkManager manager) [0x0000e] in .\Library\PackageCache\purrnet\Runtime\Transports\Interface\GenericTransport.cs:68 
  at PurrNet.NetworkManager.StartServer () [0x0002c] in .\Library\PackageCache\purrnet\Runtime\Managers\NetworkManager.cs:1015 
  at SteamLobbyManager.OnLobbyCreated (Steamworks.LobbyCreated_t param) [0x0005e] in C:\Users\Shelby\Documents\GitHub\sport-animals\Sport Animal\Assets\Code\Steam\SteamLobbyManager.cs:95 
  at Steamworks.Callback`1[T].OnRunCallback (System.IntPtr pvParam) [0x00002] in .\Library\PackageCache\com.rlabrecque.steamworks.net\Runtime\CallbackDispatcher.cs:291 
UnityEngine.DebugLogHandler:Internal_LogException_Injected(Exception, IntPtr)
UnityEngine.DebugLogHandler:Internal_LogException(Exception, Object)
UnityEngine.DebugLogHandler:LogException(Exception, Object)
UnityEngine.Logger:LogException(Exception, Object)
UnityEngine.Debug:LogException(Exception)
Steamworks.CallbackDispatcher:ExceptionHandler(Exception) (at .\Library\PackageCache\com.rlabrecque.steamworks.net\Runtime\CallbackDispatcher.cs:39)
Steamworks.Callback`1:OnRunCallback(IntPtr) (at .\Library\PackageCache\com.rlabrecque.steamworks.net\Runtime\CallbackDispatcher.cs:294)
Steamworks.CallbackDispatcher:RunFrame(Boolean) (at .\Library\PackageCache\com.rlabrecque.steamworks.net\Runtime\CallbackDispatcher.cs:191)
Steamworks.SteamAPI:RunCallbacks() (at .\Library\PackageCache\com.rlabrecque.steamworks.net\Runtime\Steam.cs:185)
SteamManager:Update() (at C:\Users\Shelby\Documents\GitHub\sport-animals\Sport Animal\Assets\Code\Steam\SteamManager.cs:169)

(Filename: ./Library/PackageCache/com.rlabrecque.steamworks.net/Runtime/CallbackDispatcher.cs Line: 39)
```