### PR TITLE
Fix post processing issue resolving generic types with circular references

### DIFF
--- a/Assets/PurrNet/Codegen/PostProcessor.cs
+++ b/Assets/PurrNet/Codegen/PostProcessor.cs
@@ -1632,10 +1632,10 @@ namespace PurrNet.Codegen
                 }
 
                 var visitedTypes = new HashSet<string>(128);
-                var typesToGenerateSerializer = new HashSet<TypeReference>(128);
-                var typesToPrepareHasher = new HashSet<TypeReference>(128);
-                var typesToIgnoreForDelta = new HashSet<TypeReference>(128);
-                var typesToIgnoreForSerialization = new HashSet<TypeReference>(128);
+                var typesToGenerateSerializer = new HashSet<TypeReference>(128, TypeReferenceEqualityComparer.Default);
+                var typesToPrepareHasher = new HashSet<TypeReference>(128, TypeReferenceEqualityComparer.Default);
+                var typesToIgnoreForDelta = new HashSet<TypeReference>(128, TypeReferenceEqualityComparer.Default);
+                var typesToIgnoreForSerialization = new HashSet<TypeReference>(128, TypeReferenceEqualityComparer.Default);
 
                 var messages = new List<DiagnosticMessage>(32);
 
@@ -1801,6 +1801,7 @@ namespace PurrNet.Codegen
                         if (inheritsFromNetworkIdentity || inheritsFromNetworkClass)
                             typesToGenerateSerializer.Add(type);
 
+                        // Note: not sure how to include equality comparer here
                         using var usedTypes = new DisposableHashSet<TypeReference>(32);
 
                         for (var index = 0; index < _rpcMethods.Count; index++)
@@ -1957,8 +1958,8 @@ namespace PurrNet.Codegen
 
         private static void ExpandNested(AssemblyDefinition assembly, HashSet<TypeReference> typesToHandle)
         {
-            HashSet<TypeReference> visited = new HashSet<TypeReference>();
-            HashSet<TypeReference> visited2 = new HashSet<TypeReference>();
+            HashSet<TypeReference> visited = new HashSet<TypeReference>(TypeReferenceEqualityComparer.Default);
+            HashSet<TypeReference> visited2 = new HashSet<TypeReference>(TypeReferenceEqualityComparer.Default);
             var copy = typesToHandle.ToArray();
 
             for (var i = 0; i < copy.Length; i++)

--- a/Assets/PurrNet/Codegen/TypeReferenceEqualityComparer.cs
+++ b/Assets/PurrNet/Codegen/TypeReferenceEqualityComparer.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace PurrNet.Codegen
+{
+    public class TypeReferenceEqualityComparer : IEqualityComparer<TypeReference>
+    {
+        private TypeReferenceEqualityComparer()
+        {
+        }
+
+        public static IEqualityComparer<TypeReference> Default { get; } = new TypeReferenceEqualityComparer();
+
+        public bool Equals(TypeReference x, TypeReference y)
+        {
+            return GetKey(x) == GetKey(y);
+        }
+
+        public int GetHashCode(TypeReference obj)
+        {
+            return GetKey(obj)?.GetHashCode() ?? 0;
+        }
+
+        private static string GetKey(TypeReference obj)
+        {
+            if (obj == null)
+                return null;
+
+            return $"{obj.GetType().FullName}|{GetAssemblyName(obj.Scope)}|{obj.FullName}";
+        }
+
+        private static string GetAssemblyName(IMetadataScope scope)
+        {
+            if (scope == null)
+                return null;
+
+            if (scope is ModuleDefinition md)
+            {
+                return md.Assembly.FullName;
+            }
+
+            return scope.ToString();
+        }
+    }
+}

--- a/Assets/PurrNet/Codegen/TypeReferenceEqualityComparer.cs.meta
+++ b/Assets/PurrNet/Codegen/TypeReferenceEqualityComparer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 28eece095d0c4ec4880b2b83878f68a8


### PR DESCRIPTION
This PR fixes the following error during code gen:
```
Processing assembly Library/Bee/artifacts/1900b0aEDbg.dag/Assembly-CSharp.dll, with 129 defines and 310 references
processors: PurrNet.Codegen.PostProcessor, Unity.Jobs.CodeGen.JobsILPostProcessor, zzzUnity.Burst.CodeGen.BurstILPostProcessor
running PurrNet.Codegen.PostProcessor
Unhandled Exception: Grpc.Core.RpcException: Status(StatusCode="Unavailable", Detail="Error reading next message. IOException: The request was aborted. IOException: The response ended prematurely while waiting for the next frame from the server.", DebugException="System.IO.IOException: The request was aborted.
 ---> System.IO.IOException: The response ended prematurely while waiting for the next frame from the server.
```

It is caused by the following situation:
```c#
using PurrNet;
using UnityEngine;

public class CustomNetworkComponent : NetworkBehaviour
{
    public struct MyStruct<T>
    {
        public MyClass<T> MyClass;
    }

    public class MyClass<T>
    {
        public MyStruct<T> MyStruct;
    }

    private MyStruct<GameObject> handle;
}
```

I believe the `PostProcessor` gets stuck in an infinite loop trying to resolve the types in `PostProcessor.ExpandNested` and likely encounters a stack overflow. I'm not sure how to actually debug the post processor, so it's a bit of an "educated guess".

**Warning! I am not familiar with how code gen works in Unity, nor am I familiar with Cecil!**

I've added a `TypeReference` equality comparer to `HashSet<TypeReference>` instances in `PostProcessor` as `TypeReference` does not implement `IEquatable`. See:
- https://mono-cecil.narkive.com/kaqG7vFV/typedefinition-equality
- https://stackoverflow.com/questions/35916226/how-to-tell-if-two-typereferences-refer-to-the-same-type
- https://github.com/jbevain/cecil/issues/389

Note: there is a `TypeReferenceEqualityComparer` in Cecil, however it is marked as `internal` and can't be used outside their assembly: https://github.com/jbevain/cecil/blob/master/Mono.Cecil/TypeReferenceEqualityComparer.cs

Note 2: the implementation of `TypeReferenceEqualityComparer` included in this PR is based on the implementation here: https://github.com/tom-englert/Substitute.Fody/blob/master/Substitute.Fody/TypeReferenceEqualityComparer.cs