### PR TITLE
fix: Add missing GetFloat(int nameHash)

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
@@ -472,6 +472,8 @@ namespace PurrNet
         public void SetFloat(string propName, float value) => SetFloat(Animator.StringToHash(propName), value);
 
         public float GetFloat(string propName) => _animator.GetFloat(propName);
+        
+        public float GetFloat(int nameHash) => _animator.GetFloat(nameHash);
 
         public void SetBool(string propName, bool value) => SetBool(Animator.StringToHash(propName), value);
 


### PR DESCRIPTION
Add's the missing NetworkAnimator.GetFloat(int nameHash) according to [Unity's Scripting API](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Animator.GetFloat.html)