### PR TITLE
Prevent state sync when NetworkTransform is disabled in OnObserverAdded and OnOwnerChanged

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
@@ -189,6 +189,10 @@ namespace PurrNet
 
         protected override void OnOwnerChanged(PlayerID? oldOwner, PlayerID? newOwner, bool asServer)
         {
+            if (!enabled) {
+                return;
+            }
+            
             if (!_wasOnSpawnedCalled)
                 return;
 
@@ -263,6 +267,10 @@ namespace PurrNet
 
         protected override void OnObserverAdded(PlayerID player)
         {
+            if (!enabled) {
+                return;
+            }
+            
             if (player == localPlayer)
                 return;
 


### PR DESCRIPTION
When NetworkTransform is disabled it shouldn't send stale or uninitialized states (in the case of starting as disabled) in OnObserverAdded() or OnOwnerChanged

