### PR TITLE
Resetting delta compression state to prevent stale reference points in NetworkTransform

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
@@ -136,6 +136,20 @@ namespace PurrNet
         private void OnEnable()
         {
             UnityLatestUpdate.onLatestUpdate += LateLateUpdate;
+            
+            if (_trs == null)
+                return;
+            
+            // Reset delta compression state to prevent stale reference points
+            _currentData = GetCurrentTransformData();
+            _latestData = _currentData;
+            _lastReadData = _currentData;
+            _lastSentDelta = _currentData;
+            
+            // Force sync if we're the controller and spawned
+            if (_wasOnSpawnedCalled && isController) {
+                ForceSync();
+            }
         }
 
         private void OnDisable()


### PR DESCRIPTION
Found a bug where network transforms diverge if the client disconnect/reconnects while the nt is disabled

Steps to reproduce:

- NetworkTransform start as disabled
- client disconnects
- client reconnects
- enable NetworkTransform

result: network transform diverges between server / client

