### PR TITLE
Fix HasModule early returning for client causing no syncing of tick

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Ticks/TickManager.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Ticks/TickManager.cs
@@ -206,7 +206,7 @@ namespace PurrNet.Modules
                 if (_networkManager.isOffline)
                     return;
 
-                if (!_networkManager.HasModule<RPCModule>())
+                if (!_networkManager.HasModule<RPCModule>(_networkManager.isServer))
                     return;
 
                 float requestSendTime = Time.unscaledTime;

--- a/Assets/PurrNet/Runtime/Managers/INetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/INetworkManager.cs
@@ -36,6 +36,6 @@ namespace PurrNet
         void InternalUnregisterClientModules();
         void InternalUnregisterServerModules();
 
-        bool HasModule<T>() where T : INetworkModule;
+        bool HasModule<T>(bool asServer) where T : INetworkModule;
     }
 }

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -588,15 +588,9 @@ namespace PurrNet
         }
 #endif
 
-        public bool HasModule<T>() where T : INetworkModule
+        public bool HasModule<T>(bool asServer) where T : INetworkModule
         {
-            if (!_serverModules.TryGetModule<T>(out _))
-                return false;
-
-            if (!_clientModules.TryGetModule<T>(out _))
-                return false;
-
-            return true;
+            return TryGetModule<T>(out _, asServer);
         }
 
         /// <summary>

--- a/Assets/PurrNet/Runtime/Managers/RawNetManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/RawNetManager.cs
@@ -328,15 +328,9 @@ namespace PurrNet
             return asServer ? _serverModules.TryGetModule(out module) : _clientModules.TryGetModule(out module);
         }
 
-        public bool HasModule<T>() where T : INetworkModule
+        public bool HasModule<T>(bool asServer) where T : INetworkModule
         {
-            if (!_serverModules.TryGetModule<T>(out _))
-                return false;
-
-            if (!_clientModules.TryGetModule<T>(out _))
-                return false;
-
-            return true;
+            return TryGetModule<T>(out _, asServer);
         }
 
         private void Update()


### PR DESCRIPTION
This is confirmed fixing the issue I had where clients didn't get synced ticks synced. Note that this does change the signature of HasModule, but it does so to bring it in line with other common functions like TryGetModule. If the desired behavior is to have the manager check itself for isServer/isClient and look in the appropriate lists that is fine too, as long as host can check both.