### PR TITLE
feat: Run context guarded methods

### DIFF
--- a/Assets/PurrNet/Codegen/PostProcessor.cs
+++ b/Assets/PurrNet/Codegen/PostProcessor.cs
@@ -1129,6 +1129,26 @@ namespace PurrNet.Codegen
             }
         }
 
+        static GuardFailureAction GetMode(PurrNetSettings settings, GuardFailureActionOverride overrideAction)
+        {
+            switch (overrideAction)
+            {
+                case GuardFailureActionOverride.ReturnDefault:
+                    return GuardFailureAction.ReturnDefault;
+                case GuardFailureActionOverride.ThrowException:
+                    return GuardFailureAction.ThrowException;
+                case GuardFailureActionOverride.LogWarning:
+                    return GuardFailureAction.LogWarning;
+                case GuardFailureActionOverride.LogError:
+                    return GuardFailureAction.LogError;
+                case GuardFailureActionOverride.Ignore:
+                    return GuardFailureAction.Ignore;
+                case GuardFailureActionOverride.Settings:
+                default:
+                    return settings.guardFailureAction;
+            }
+        }
+
         private static void StripBody(MethodDefinition method, string methodName, PurrNetSettings settings, StripCodeModeOverride overrideMode)
         {
             var mode = GetMode(settings, overrideMode);
@@ -2262,7 +2282,11 @@ namespace PurrNet.Codegen
                         if (!type.IsClass)
                         {
                             for (var i = 0; i < type.Methods.Count; i++)
-                                ProcessServerOnlyMethods(type.Methods[i], settings, isServerBuild, isEditor);
+                            {
+                                var method = type.Methods[i];
+                                ProcessServerOnlyMethods(method, settings, isServerBuild, isEditor);
+                                ProcessRunContextGuardedMethods(method, settings, false);
+                            }
                             continue;
                         }
 
@@ -2302,7 +2326,8 @@ namespace PurrNet.Codegen
                             try
                             {
                                 var method = type.Methods[i];
-                                ProcessServerOnlyMethods(type.Methods[i], settings, isServerBuild, isEditor);
+                                ProcessServerOnlyMethods(method, settings, isServerBuild, isEditor);
+                                ProcessRunContextGuardedMethods(method, settings, inheritsFromNetworkIdentity);
 
                                 if (inheritsFromNetworkIdentity && MakeSureOverrideIsCalled.ShouldProcess(method))
                                     MakeSureOverrideIsCalled.Process(method, messages);
@@ -2545,6 +2570,150 @@ namespace PurrNet.Codegen
                 .GetMethod.Import(module);
             var getIsServer = Instruction.Create(OpCodes.Call, isServerOnlyProp);
             return getIsServer;
+        }
+
+        private static Instruction GetIsClientMethod(ModuleDefinition module)
+        {
+            var isClientProp = module.GetTypeDefinition<NetworkManager>()
+                .GetProperty("isClientStatic")
+                .GetMethod.Import(module);
+            var getIsClient = Instruction.Create(OpCodes.Call, isClientProp);
+            return getIsClient;
+        }
+
+        private static void ProcessRunContextGuardedMethods(MethodDefinition method, PurrNetSettings settings, bool inheritsFromNetworkIdentity)
+        {
+            if (method.Body == null) return;
+
+            bool hasServer = false;
+            bool hasClient = false;
+            bool hasOwner = false;
+
+            var guardFailureActionOverride = GuardFailureActionOverride.Settings;
+
+            foreach (var attribute in method.CustomAttributes)
+            {
+                string fullName = attribute.AttributeType.FullName;
+                if (!hasServer && fullName == typeof(ServerAttribute).FullName)
+                {
+                    hasServer = true;
+                }
+                else if (!hasClient && fullName == typeof(ClientAttribute).FullName)
+                {
+                    hasClient = true;
+                }
+                else if (!hasOwner && fullName == typeof(OwnerAttribute).FullName)
+                {
+                    hasOwner = true;
+                }
+                else if (fullName == typeof(GuardFailureActionAttribute).FullName)
+                {
+                    guardFailureActionOverride = (GuardFailureActionOverride)attribute.ConstructorArguments[0].Value;
+                }
+            }
+
+            if (!hasServer && !hasClient && !hasOwner)
+                return;
+
+            var guardFailureAction = GetMode(settings, guardFailureActionOverride);
+            if (guardFailureAction == GuardFailureAction.Ignore) return;
+
+            // insert guard
+            var il = method.Body.GetILProcessor();
+            var firstInstruction = method.Body.Instructions[0];
+            var module = method.Module;
+
+            var failureHandler = CreateGuardFailureActionHandler(method, il, guardFailureAction);
+
+            if (hasServer)
+            {
+                if (inheritsFromNetworkIdentity)
+                {
+                    CheckNetworkIdentityProperty("isServer", module, il, firstInstruction);
+                }
+                else
+                {
+                    var callIsServer = GetIsServerMethod(module);
+                    il.InsertBefore(firstInstruction, callIsServer);
+                    il.InsertAfter(callIsServer, il.Create(OpCodes.Brtrue, firstInstruction));
+                }
+            }
+
+            if (hasClient)
+            {
+                if (inheritsFromNetworkIdentity)
+                {
+                    CheckNetworkIdentityProperty("isClient", module, il, firstInstruction);
+                }
+                else
+                {
+                    var callIsClient = GetIsClientMethod(module);
+                    il.InsertBefore(firstInstruction, callIsClient);
+                    il.InsertAfter(callIsClient, il.Create(OpCodes.Brtrue, firstInstruction));
+                }
+            }
+
+            if (hasOwner)
+            {
+                if (!inheritsFromNetworkIdentity)
+                    throw new InvalidOperationException($"[Owner] requires {method.DeclaringType.Name} to inherit NetworkIdentity.");
+
+                CheckNetworkIdentityProperty("isOwner", module, il, firstInstruction);
+            }
+
+            il.InsertBefore(firstInstruction, il.Create(OpCodes.Br, failureHandler));
+        }
+
+        private static Instruction CreateGuardFailureActionHandler(
+            MethodDefinition method,
+            ILProcessor il,
+            GuardFailureAction action)
+        {
+            var handler = il.Create(OpCodes.Nop);
+            il.Append(handler);
+
+            switch (action)
+            {
+                case GuardFailureAction.ReturnDefault:
+                    break;
+                case GuardFailureAction.ThrowException:
+                    var throwExcep = method.Module.GetTypeDefinition(typeof(PurrLogger))
+                        .GetMethod("ThrowUnsupportedException", false).Import(method.Module);
+                    il.Append(il.Create(OpCodes.Ldstr, $"Method '{method.DeclaringType.Name}.{method.Name}' cannot be called from this context."));
+                    il.Append(il.Create(OpCodes.Call, throwExcep));
+                    break;
+                case GuardFailureAction.LogWarning:
+                    var logWarningMethod = method.Module.GetTypeDefinition(typeof(PurrLogger))
+                        .GetMethod("LogSimplerWarning", false).Import(method.Module);
+                    il.Append(il.Create(OpCodes.Ldstr, $"Method '{method.DeclaringType.Name}.{method.Name}' cannot be called from this context."));
+                    il.Append(il.Create(OpCodes.Call, logWarningMethod));
+                    break;
+                case GuardFailureAction.LogError:
+                    var logErrorMethod = method.Module.GetTypeDefinition(typeof(PurrLogger))
+                        .GetMethod("LogSimplerError", false).Import(method.Module);
+                    il.Append(il.Create(OpCodes.Ldstr, $"Method '{method.DeclaringType.Name}.{method.Name}' cannot be called from this context."));
+                    il.Append(il.Create(OpCodes.Call, logErrorMethod));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            ProperlyEndMethod(method, il);
+
+            return handler;
+        }
+
+        private static void CheckNetworkIdentityProperty(string property, ModuleDefinition module, ILProcessor il, Instruction target)
+        {
+            var networkIdentityType = module.GetTypeDefinition<NetworkIdentity>().Resolve();
+            var isOwnerGetter = networkIdentityType
+                .GetProperty(property)
+                .GetMethod.Import(module);
+
+            var ldarg0 = il.Create(OpCodes.Ldarg_0);
+            il.InsertBefore(target, ldarg0);
+            il.InsertAfter(ldarg0, il.Create(OpCodes.Callvirt, isOwnerGetter));
+            il.InsertAfter(ldarg0.Next, il.Create(OpCodes.Brtrue, target));
         }
 
         private static void IncludeAnyConcreteGenericParameters(TypeDefinition type,

--- a/Assets/PurrNet/Codegen/PostProcessor.cs
+++ b/Assets/PurrNet/Codegen/PostProcessor.cs
@@ -2627,30 +2627,16 @@ namespace PurrNet.Codegen
 
             if (hasServer)
             {
-                if (inheritsFromNetworkIdentity)
-                {
-                    CheckNetworkIdentityProperty("isServer", module, il, firstInstruction);
-                }
-                else
-                {
-                    var callIsServer = GetIsServerMethod(module);
-                    il.InsertBefore(firstInstruction, callIsServer);
-                    il.InsertAfter(callIsServer, il.Create(OpCodes.Brtrue, firstInstruction));
-                }
+                var callIsServer = GetIsServerMethod(module);
+                il.InsertBefore(firstInstruction, callIsServer);
+                il.InsertAfter(callIsServer, il.Create(OpCodes.Brtrue, firstInstruction));
             }
 
             if (hasClient)
             {
-                if (inheritsFromNetworkIdentity)
-                {
-                    CheckNetworkIdentityProperty("isClient", module, il, firstInstruction);
-                }
-                else
-                {
-                    var callIsClient = GetIsClientMethod(module);
-                    il.InsertBefore(firstInstruction, callIsClient);
-                    il.InsertAfter(callIsClient, il.Create(OpCodes.Brtrue, firstInstruction));
-                }
+                var callIsClient = GetIsClientMethod(module);
+                il.InsertBefore(firstInstruction, callIsClient);
+                il.InsertAfter(callIsClient, il.Create(OpCodes.Brtrue, firstInstruction));
             }
 
             if (hasOwner)

--- a/Assets/PurrNet/Editor/Settings/PurrNetEditorSettings.cs
+++ b/Assets/PurrNet/Editor/Settings/PurrNetEditorSettings.cs
@@ -42,12 +42,19 @@ namespace PurrNet.Editor
 
             GUILayout.Space(10f);
 
-            var result = EditorGUILayout.EnumPopup(
+            var stripCodeModeResult = EditorGUILayout.EnumPopup(
                 new GUIContent("Strip Code Mode",
                     "Defines how PurrNet will handle unused RPCs and SyncVars in builds. " +
                     "This can help reduce build size and improve performance."),
                 settings.stripCodeMode);
-            settings.stripCodeMode = (StripCodeMode)result;
+            settings.stripCodeMode = (StripCodeMode)stripCodeModeResult;
+
+            var guardFailureActionResult = EditorGUILayout.EnumPopup(
+                new GUIContent("Guard Failure Action",
+                    "Defines how PurrNet will handle run context guarded methods. " +
+                    "This can help organize your code."),
+                settings.guardFailureAction);
+            settings.guardFailureAction = (GuardFailureAction)guardFailureActionResult;
 
             if (EditorGUI.EndChangeCheck())
                 PurrNetSettings.SaveSettings(settings);

--- a/Assets/PurrNet/Editor/Settings/PurrNetSettings.cs
+++ b/Assets/PurrNet/Editor/Settings/PurrNetSettings.cs
@@ -19,6 +19,7 @@ namespace PurrNet.Editor
         static object _lock = new object();
 
         public StripCodeMode stripCodeMode = StripCodeMode.DoNotStrip;
+        public GuardFailureAction guardFailureAction = GuardFailureAction.ReturnDefault;
 
         public ToolbarMode toolbarMode = ToolbarMode.Full;
         public bool toolbarTransportDropDown;

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/GuardFailureAction.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/GuardFailureAction.cs
@@ -1,0 +1,32 @@
+using System;
+using JetBrains.Annotations;
+using UnityEngine.Scripting;
+
+namespace PurrNet
+{
+    public enum GuardFailureAction
+    {
+        ReturnDefault,
+        ThrowException,
+        LogWarning,
+        LogError,
+        Ignore,
+    }
+
+    public enum GuardFailureActionOverride
+    {
+        Settings,
+        ReturnDefault,
+        ThrowException,
+        LogWarning,
+        LogError,
+        Ignore,
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class GuardFailureActionAttribute : PreserveAttribute
+    {
+        [UsedImplicitly]
+        public GuardFailureActionAttribute(GuardFailureActionOverride guardFailureAction = GuardFailureActionOverride.Settings) { }
+    }
+}

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/GuardFailureAction.cs.meta
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/GuardFailureAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc4c1c3442ac59b488bd29b64acf9a5d

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RunContextAttributes.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RunContextAttributes.cs
@@ -5,21 +5,21 @@ using UnityEngine.Scripting;
 namespace PurrNet
 {
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    public class ServerAttribute : PreserveAttribute
+    public sealed class ServerAttribute : PreserveAttribute
     {
         [UsedImplicitly]
         public ServerAttribute() { }
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    public class OwnerAttribute : PreserveAttribute
+    public sealed class OwnerAttribute : PreserveAttribute
     {
         [UsedImplicitly]
         public OwnerAttribute() { }
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    public class ClientAttribute : PreserveAttribute
+    public sealed class ClientAttribute : PreserveAttribute
     {
         [UsedImplicitly]
         public ClientAttribute() { }

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RunContextAttributes.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RunContextAttributes.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using JetBrains.Annotations;
+using UnityEngine.Scripting;
+
+namespace PurrNet
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class ServerAttribute : PreserveAttribute
+    {
+        [UsedImplicitly]
+        public ServerAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class OwnerAttribute : PreserveAttribute
+    {
+        [UsedImplicitly]
+        public OwnerAttribute() { }
+    }
+
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public class ClientAttribute : PreserveAttribute
+    {
+        [UsedImplicitly]
+        public ClientAttribute() { }
+    }
+}

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RunContextAttributes.cs.meta
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RunContextAttributes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0f4118b2c2e50546a182fea886c94d2

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -255,6 +255,9 @@ namespace PurrNet
         [UsedByIL]
         public static bool isServerStatic => main && main.isServer;
 
+        [UsedByIL]
+        public static bool isClientStatic => main && main.isClient;
+
         /// <summary>
         /// Whether the network manager is a client.
         /// </summary>


### PR DESCRIPTION
Adds **[Server]**, **[Client]**, **[Owner]**, and **[GuardFailureAction]** attributes.
These are simply guard clauses that can be used for both functionality purposes, and purely organizational purposes if you want.

# NetworkIdentity
[Server], [Client] and [Owner] attributes can be used on NetworkIdentity classes:
```cs
public class TestClass : NetworkIdentity {
    [Server, Client, Owner]
    private void Test() {
        Debug.Log("Test");
    }
}
```
This converts to something like:
```cs
public class TestClass : NetworkIdentity {
    private void Test() {
        if (NetworkManager.isServerStatic || NetworkManager.isClientStatic || isOwner) {
            Debug.Log("Test");
        }
    }
}
```

These can be mixed and matched to fit your method needs.

# Non-NetworkIdentity

[Server] and [Client] can be used on Non-NetworkIdentity classes:
```cs
public class TestClass {
    [Server, Client]
    private void Test() {
        Debug.Log("Test");
    }
}
```
This converts to something like:
```cs
public class TestClassNonMono {
    private void Test() {
        if (NetworkManager.isServerStatic || NetworkManager.isClientStatic) {
            Debug.Log("Test");
        }
    }
}
```

# Failure Action
You can also set the failure action, to change what happens when you're running from the wrong context. This works on all classes.
```cs
public class TestClass {
    [Server, Client, Owner]
    [GuardFailureAction(GuardFailureActionOverride.LogWarning)]
    private void Test() {
        Debug.Log("Test");
    }
}
```
The default failure action can be set in **Project Settings > Multiplayer > PurrNet > Guard Failure Action**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add Server, Client, and Owner method attributes to restrict RPC/method execution by run context.
  * Introduce Guard Failure Action enums and a method-level override attribute (ReturnDefault/ThrowException/LogWarning/LogError/Ignore).
  * Inject automatic runtime guards at method entry (including ownership checks) with configurable failure behavior.
  * New editor setting to choose and persist the default Guard Failure Action.
  * Add a public client-state accessor to enable client-side run-context checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->