### PR TITLE
Adds scene cleanup mode to NetworkRules

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkRules.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkRules.cs
@@ -2,9 +2,28 @@ using System;
 using JetBrains.Annotations;
 using PurrNet.Utils;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace PurrNet
 {
+    public enum SceneCleanupMode
+    {
+        /// <summary>
+        /// Do not cleanup any scenes on disconnect.
+        /// </summary>
+        Off,
+
+        /// <summary>
+        /// Cleanup scenes that were loaded through the network, and load the starting scene additively.
+        /// </summary>
+        OnlineScenesOnly,
+
+        /// <summary>
+        /// Cleanup all scenes and load the start scene in single mode.
+        /// </summary>
+        AllScenes
+    }
+
     [Serializable]
     public struct VisibilityRules
     {
@@ -38,6 +57,7 @@ namespace PurrNet
 
         [Tooltip("If owner disconnects, should the object despawn or stay in the scene?")]
         public bool despawnIfOwnerDisconnects;
+
         [Tooltip("On disconnect, despawn all objects that were spawned during the session")]
         public bool cleanupSpawnedObjects;
     }
@@ -59,13 +79,39 @@ namespace PurrNet
     }
 
     [Serializable]
-    public struct NetworkSceneRules
+    public struct NetworkSceneRules : ISerializationCallbackReceiver
     {
+        [FormerlySerializedAs("cleanupScenesOnDisconnect")]
+        [SerializeField, HideInInspector]
+        private bool _cleanupScenesOnDisconnect;
+
         public bool removePlayerFromSceneOnDisconnect;
-        [Tooltip("On disconnect, unload all scenes that were loaded during the session and reload the starting scene")]
-        public bool cleanupScenesOnDisconnect;
+
+        [Tooltip("On disconnect, unload scenes based on the cleanup mode and load the starting scene")]
+        public SceneCleanupMode sceneCleanupModeOnDisconnect;
 
         public bool alwaysIncludeDontDestroyOnLoadScene;
+
+        [Obsolete("Use sceneCleanupModeOnDisconnect instead.")]
+        public bool cleanupScenesOnDisconnect
+        {
+            readonly get => sceneCleanupModeOnDisconnect == SceneCleanupMode.OnlineScenesOnly;
+            set => sceneCleanupModeOnDisconnect = value ? SceneCleanupMode.OnlineScenesOnly : SceneCleanupMode.Off;
+        }
+
+        public readonly void OnBeforeSerialize()
+        {
+            return;
+        }
+
+        public void OnAfterDeserialize()
+        {
+            if (_cleanupScenesOnDisconnect && sceneCleanupModeOnDisconnect != SceneCleanupMode.OnlineScenesOnly)
+            {
+                sceneCleanupModeOnDisconnect = SceneCleanupMode.OnlineScenesOnly;
+                _cleanupScenesOnDisconnect = false;
+            }
+        }
     }
 
     [Serializable]
@@ -89,7 +135,8 @@ namespace PurrNet
     [CreateAssetMenu(fileName = "NetworkRules", menuName = "PurrNet/Network Rules", order = -201)]
     public class NetworkRules : ScriptableObject
     {
-        [SerializeField] private SpawnRules _defaultSpawnRules = new SpawnRules
+        [SerializeField]
+        private SpawnRules _defaultSpawnRules = new SpawnRules
         {
             despawnAuth = ActionAuth.Server | ActionAuth.Owner,
             spawnAuth = ConnectionAuth.Server,
@@ -99,43 +146,50 @@ namespace PurrNet
             cleanupSpawnedObjects = true
         };
 
-        [SerializeField] private RpcRules _defaultRpcRules = new RpcRules
+        [SerializeField]
+        private RpcRules _defaultRpcRules = new RpcRules
         {
             ignoreRequireServerAttribute = false,
             ignoreRequireOwnerAttribute = false
         };
 
-        [PurrReadOnly, UsedImplicitly] [SerializeField]
+        [PurrReadOnly, UsedImplicitly]
+        [SerializeField]
         private VisibilityRules _defaultVisibilityRules = new VisibilityRules
         {
             visibilityMode = VisibilityMode.SpawnDespawn
         };
 
-        [SerializeField] private OwnershipRules _defaultOwnershipRules = new OwnershipRules
+        [SerializeField]
+        private OwnershipRules _defaultOwnershipRules = new OwnershipRules
         {
             assignAuth = ConnectionAuth.Server,
             transferAuth = ActionAuth.Owner | ActionAuth.Server,
             overrideWhenPropagating = true
         };
 
-        [SerializeField] private NetworkSceneRules _defaultSceneRules = new NetworkSceneRules
+        [SerializeField]
+        private NetworkSceneRules _defaultSceneRules = new NetworkSceneRules
         {
             removePlayerFromSceneOnDisconnect = false,
-            cleanupScenesOnDisconnect = true,
+            sceneCleanupModeOnDisconnect = SceneCleanupMode.OnlineScenesOnly,
             alwaysIncludeDontDestroyOnLoadScene = false
         };
 
-        [SerializeField] private NetworkIdentityRules _defaultIdentityRules = new NetworkIdentityRules
+        [SerializeField]
+        private NetworkIdentityRules _defaultIdentityRules = new NetworkIdentityRules
         {
             receiveRpcsWhenDisabled = true
         };
 
-        [SerializeField] private NetworkTransformRules _defaultTransformRules = new NetworkTransformRules
+        [SerializeField]
+        private NetworkTransformRules _defaultTransformRules = new NetworkTransformRules
         {
             changeParentAuth = ActionAuth.Server | ActionAuth.Owner
         };
 
-        [SerializeField] private MiscRules _defaultMiscRules = new MiscRules
+        [SerializeField]
+        private MiscRules _defaultMiscRules = new MiscRules
         {
             syncedTickUpdateInterval = 1
         };
@@ -245,7 +299,12 @@ namespace PurrNet
 
         public bool ShouldCleanupScenesOnDisconnect()
         {
-            return _defaultSceneRules.cleanupScenesOnDisconnect;
+            return _defaultSceneRules.sceneCleanupModeOnDisconnect != SceneCleanupMode.Off;
+        }
+
+        public SceneCleanupMode SceneCleanupModeOnDisconnect()
+        {
+            return _defaultSceneRules.sceneCleanupModeOnDisconnect;
         }
 
         public bool ShouldAlwaysIncludeDontDestroyOnLoadScene()

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -404,78 +404,78 @@ namespace PurrNet.Modules
             switch (action.type)
             {
                 case SceneActionType.Load:
-                {
-                    if (_networkManager.isHost && !_asServer)
                     {
-                        _actionsQueue.Dequeue();
-                        break;
-                    }
-
-                    var loadAction = action.loadSceneAction;
-                    AsyncOperation operation;
-
-                    try
-                    {
-                        operation = SceneManager.LoadSceneAsync(loadAction.buildIndex, loadAction.GetLoadSceneParameters());
-                    }
-                    catch (System.Exception e)
-                    {
-                        PurrLogger.LogError($"Error loading scene: {e}");
-                        break;
-                    }
-
-                    if (loadAction.parameters.mode == LoadSceneMode.Single)
-                    {
-                        for (int i = 0; i < _rawScenes.Count; i++)
+                        if (_networkManager.isHost && !_asServer)
                         {
-                            if (!IsDontDestroyOnLoadScene(_scenes[_rawScenes[i]].scene))
-                                RemoveScene(_scenes[_rawScenes[i]].scene);
+                            _actionsQueue.Dequeue();
+                            break;
                         }
-                    }
 
-                    _pendingOperations.Add(new PendingSceneOperation
-                    {
-                        buildIndex = loadAction.buildIndex,
-                        settings = loadAction.parameters,
-                        idToAssign = loadAction.sceneID,
-                        operation = operation
-                    });
+                        var loadAction = action.loadSceneAction;
+                        AsyncOperation operation;
 
-                    _actionsQueue.Dequeue();
-                    break;
-                }
-                case SceneActionType.Unload:
-                {
-                    var currentlyLoadedCount = GetCurrentLoadedScenes();
-                    if (currentlyLoadedCount == 1)
-                    {
-                        // wait for the next load action
-                        break;
-                    }
+                        try
+                        {
+                            operation = SceneManager.LoadSceneAsync(loadAction.buildIndex, loadAction.GetLoadSceneParameters());
+                        }
+                        catch (System.Exception e)
+                        {
+                            PurrLogger.LogError($"Error loading scene: {e}");
+                            break;
+                        }
 
-                    var idx = action.unloadSceneAction.sceneID;
+                        if (loadAction.parameters.mode == LoadSceneMode.Single)
+                        {
+                            for (int i = 0; i < _rawScenes.Count; i++)
+                            {
+                                if (!IsDontDestroyOnLoadScene(_scenes[_rawScenes[i]].scene))
+                                    RemoveScene(_scenes[_rawScenes[i]].scene);
+                            }
+                        }
 
-                    if (_networkManager.isHost && !_asServer)
-                    {
-                        _scenesToTriggerUnloadEvent.Add(idx);
+                        _pendingOperations.Add(new PendingSceneOperation
+                        {
+                            buildIndex = loadAction.buildIndex,
+                            settings = loadAction.parameters,
+                            idToAssign = loadAction.sceneID,
+                            operation = operation
+                        });
+
                         _actionsQueue.Dequeue();
                         break;
                     }
-
-                    // if the scene is pending, don't do anything for now
-                    if (IsScenePending(idx)) break;
-
-                    if (!_scenes.TryGetValue(idx, out var sceneState))
+                case SceneActionType.Unload:
                     {
-                        PurrLogger.LogError($"Couldn't find scene with index {idx} to unload");
+                        var currentlyLoadedCount = GetCurrentLoadedScenes();
+                        if (currentlyLoadedCount == 1)
+                        {
+                            // wait for the next load action
+                            break;
+                        }
+
+                        var idx = action.unloadSceneAction.sceneID;
+
+                        if (_networkManager.isHost && !_asServer)
+                        {
+                            _scenesToTriggerUnloadEvent.Add(idx);
+                            _actionsQueue.Dequeue();
+                            break;
+                        }
+
+                        // if the scene is pending, don't do anything for now
+                        if (IsScenePending(idx)) break;
+
+                        if (!_scenes.TryGetValue(idx, out var sceneState))
+                        {
+                            PurrLogger.LogError($"Couldn't find scene with index {idx} to unload");
+                            break;
+                        }
+
+                        SceneManager.UnloadSceneAsync(sceneState.scene, action.unloadSceneAction.options);
+                        RemoveScene(sceneState.scene);
+                        _actionsQueue.Dequeue();
                         break;
                     }
-
-                    SceneManager.UnloadSceneAsync(sceneState.scene, action.unloadSceneAction.options);
-                    RemoveScene(sceneState.scene);
-                    _actionsQueue.Dequeue();
-                    break;
-                }
             }
         }
 
@@ -491,23 +491,23 @@ namespace PurrNet.Modules
                     switch (action.type)
                     {
                         case SceneActionType.Load:
-                        {
-                            if (_scenes.ContainsKey(action.loadSceneAction.sceneID))
-                                continue;
+                            {
+                                if (_scenes.ContainsKey(action.loadSceneAction.sceneID))
+                                    continue;
 
-                            if (serverModule.TryGetSceneState(action.loadSceneAction.sceneID, out var state))
-                                AddScene(state.scene, state.settings, action.loadSceneAction.sceneID);
-                            break;
-                        }
+                                if (serverModule.TryGetSceneState(action.loadSceneAction.sceneID, out var state))
+                                    AddScene(state.scene, state.settings, action.loadSceneAction.sceneID);
+                                break;
+                            }
                         case SceneActionType.Unload:
-                        {
-                            if (!_scenes.ContainsKey(action.unloadSceneAction.sceneID))
-                                continue;
+                            {
+                                if (!_scenes.ContainsKey(action.unloadSceneAction.sceneID))
+                                    continue;
 
-                            if (serverModule.TryGetSceneState(action.unloadSceneAction.sceneID, out var state))
-                                RemoveScene(state.scene);
-                            break;
-                        }
+                                if (serverModule.TryGetSceneState(action.unloadSceneAction.sceneID, out var state))
+                                    RemoveScene(state.scene);
+                                break;
+                            }
 
                         case SceneActionType.SetActive:
                         default:
@@ -857,6 +857,7 @@ namespace PurrNet.Modules
             UnloadScenes,
             UnloadScenesOnly,
             LoadOGScene,
+            LoadOGSceneOnly,
             UnloadEmptyScene,
             ResetScene,
             Done
@@ -887,93 +888,124 @@ namespace PurrNet.Modules
             switch (_cleanupStage)
             {
                 case CleanupStage.None:
-                {
-                    _cleanupStage = _networkManager.IsDontDestroyOnLoad()
-                        ? CleanupStage.LoadEmptyScene
-                        : CleanupStage.UnloadScenesOnly;
+                    {
+                        if (rules.SceneCleanupModeOnDisconnect() == SceneCleanupMode.AllScenes)
+                        {
+                            if (_networkManager.originalSceneBuildIndex == -1)
+                            {
+                                PurrLogger.LogError("Unable to load original scene on cleanup because its index is invalid");
+                                _cleanupStage = CleanupStage.Skip;
+                            }
+                            else
+                                _cleanupStage = CleanupStage.LoadOGSceneOnly;
+                        }
+                        else
+                        {
+                            _cleanupStage = _networkManager.IsDontDestroyOnLoad()
+                                ? CleanupStage.LoadEmptyScene
+                                : CleanupStage.UnloadScenesOnly;
+                        }
 
-                    if (_networkManager.TryGetModule(!_asServer, out ScenesModule module) && module._wasSetup)
-                        module._cleanupStage = CleanupStage.Skip;
+                        if (_networkManager.TryGetModule(!_asServer, out ScenesModule module) && module._wasSetup)
+                            module._cleanupStage = CleanupStage.Skip;
 
-                    return false;
-                }
+                        return false;
+                    }
                 case CleanupStage.Skip: return false;
                 case CleanupStage.Done: return true;
                 case CleanupStage.LoadEmptyScene:
-                {
-                    _cleanupStage = CleanupStage.WaitOneFrame;
-                    _emptyScene = SceneManager.CreateScene("EmptyScene");
-                    return false;
-                }
-                case CleanupStage.WaitOneFrame:
-                {
-                    _cleanupStage = CleanupStage.UnloadScenes;
-                    return false;
-                }
-                case CleanupStage.UnloadScenes:
-                {
-                    if (UnloadAllScenesCleanup(false))
-                        _cleanupStage = CleanupStage.LoadOGScene;
-                    return false;
-                }
-                case CleanupStage.UnloadScenesOnly:
-                {
-                    if (UnloadAllScenesCleanup(true))
                     {
-                        if (_networkManager.TryGetModule(!_asServer, out ScenesModule module))
-                            module._cleanupStage = CleanupStage.Done;
-                        _cleanupStage = CleanupStage.Done;
+                        _cleanupStage = CleanupStage.WaitOneFrame;
+                        _emptyScene = SceneManager.CreateScene("EmptyScene");
+                        return false;
                     }
-
-                    return false;
-                }
-                case CleanupStage.LoadOGScene:
-                {
-                    if (_ogSceneLoad == null)
+                case CleanupStage.WaitOneFrame:
                     {
-                        if (_networkManager.originalSceneBuildIndex != -1)
+                        _cleanupStage = CleanupStage.UnloadScenes;
+                        return false;
+                    }
+                case CleanupStage.UnloadScenes:
+                    {
+                        if (UnloadAllScenesCleanup(false))
+                            _cleanupStage = CleanupStage.LoadOGScene;
+                        return false;
+                    }
+                case CleanupStage.UnloadScenesOnly:
+                    {
+                        if (UnloadAllScenesCleanup(true))
                         {
-                            _ogSceneLoad = SceneManager.LoadSceneAsync(_networkManager.originalSceneBuildIndex,
-                                LoadSceneMode.Additive);
+                            if (_networkManager.TryGetModule(!_asServer, out ScenesModule module))
+                                module._cleanupStage = CleanupStage.Done;
+                            _cleanupStage = CleanupStage.Done;
+                        }
+
+                        return false;
+                    }
+                case CleanupStage.LoadOGScene:
+                    {
+                        if (_ogSceneLoad == null)
+                        {
+                            if (_networkManager.originalSceneBuildIndex != -1)
+                            {
+                                _ogSceneLoad = SceneManager.LoadSceneAsync(_networkManager.originalSceneBuildIndex,
+                                    LoadSceneMode.Additive);
+
+                                if (_ogSceneLoad != null)
+                                    _ogSceneLoad.allowSceneActivation = true;
+                            }
+                            else
+                            {
+                                _cleanupStage = CleanupStage.UnloadEmptyScene;
+                            }
+                        }
+
+                        if (_ogSceneLoad is { isDone: true })
+                        {
+                            _cleanupStage = CleanupStage.ResetScene;
+                        }
+
+                        return false;
+                    }
+                case CleanupStage.LoadOGSceneOnly:
+                    {
+                        if (_ogSceneLoad == null)
+                        {
+                            _ogSceneLoad = SceneManager.LoadSceneAsync(_networkManager.originalSceneBuildIndex);
 
                             if (_ogSceneLoad != null)
                                 _ogSceneLoad.allowSceneActivation = true;
                         }
-                        else
+
+                        if (_ogSceneLoad is { isDone: true })
                         {
-                            _cleanupStage = CleanupStage.UnloadEmptyScene;
+                            _scenes.Clear();
+                            _cleanupStage = CleanupStage.Done;
                         }
-                    }
 
-                    if (_ogSceneLoad is { isDone: true })
-                    {
-                        _cleanupStage = CleanupStage.ResetScene;
-                    }
-
-                    return false;
-                }
-                case CleanupStage.ResetScene:
-                {
-                    var activeScene = SceneManager.GetSceneByBuildIndex(_networkManager.originalSceneBuildIndex);
-                    _networkManager.ResetOriginalScene(activeScene);
-                    _cleanupStage = CleanupStage.UnloadEmptyScene;
-                    return false;
-                }
-                case CleanupStage.UnloadEmptyScene:
-                {
-                    if (_emptyScene != null)
-                    {
-                        if (_emptyScene.Value.IsValid())
-                            SceneManager.UnloadSceneAsync(_emptyScene.Value);
-                        _emptyScene = null;
                         return false;
                     }
+                case CleanupStage.ResetScene:
+                    {
+                        var activeScene = SceneManager.GetSceneByBuildIndex(_networkManager.originalSceneBuildIndex);
+                        _networkManager.ResetOriginalScene(activeScene);
+                        _cleanupStage = CleanupStage.UnloadEmptyScene;
+                        return false;
+                    }
+                case CleanupStage.UnloadEmptyScene:
+                    {
+                        if (_emptyScene != null)
+                        {
+                            if (_emptyScene.Value.IsValid())
+                                SceneManager.UnloadSceneAsync(_emptyScene.Value);
+                            _emptyScene = null;
+                            return false;
+                        }
 
-                    if (_networkManager.TryGetModule(!_asServer, out ScenesModule module))
-                        module._cleanupStage = CleanupStage.Done;
-                    _cleanupStage = CleanupStage.Done;
-                    return false;
-                }
+                        if (_networkManager.TryGetModule(!_asServer, out ScenesModule module))
+                            module._cleanupStage = CleanupStage.Done;
+                        _cleanupStage = CleanupStage.Done;
+                        return false;
+                    }
                 default: return true;
             }
         }

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -1168,7 +1168,7 @@ namespace PurrNet
             if (clientConnected)
                 _clientModules.TriggerOnPreFixedUpdate();
 
-            if (_transport)
+            if (_transport && (serverConnected || clientConnected))
                 _transport.transport.ReceiveMessages(delta);
 
             if (serverConnected)
@@ -1183,7 +1183,7 @@ namespace PurrNet
             if (clientConnected)
                 _clientModules.TriggerOnPostFixedUpdate();
 
-            if (_transport)
+            if (_transport && (serverConnected || clientConnected))
                 _transport.transport.SendMessages(delta);
 
             if (_isCleaningClient && _clientModules.Cleanup())


### PR DESCRIPTION
- Adds a SceneCleanupMode enum that allows for loading the original scene in Single mode (replacing all scenes). Includes a migration path and marks the existing network rule property as obsolete.
- Fixes a NullReferenceException in OnTick in NetworkManager on scene cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Configurable scene cleanup mode on disconnect (Off, OnlineScenesOnly, AllScenes).
  * Option to clean up spawned objects during scene cleanup.
  * Enhanced cleanup flow with “Load original scene only.”

* Bug Fixes
  * Network messages are processed only when a server or client is connected.
  * More robust scene load/unload with safer fallbacks and clearer errors.

* Refactor
  * Reorganized scene action handling for clarity and consistency without altering core behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->