### PR TITLE
feat: Allow Dynamic SpawnPosition in PlayerSpawner

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/PlayerSpawner.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/PlayerSpawner.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using PurrNet.Logging;
 using PurrNet.Modules;
@@ -14,6 +15,12 @@ namespace PurrNet
 
         [SerializeField] private List<Transform> spawnPoints = new List<Transform>();
         private int _currentSpawnPoint;
+
+        /// <summary>
+        /// Instance-level event hook that allows custom spawn positions.
+        /// Return null to let the spawner fall back to default logic.
+        /// </summary>
+        public event Func<PlayerID, SceneID, bool, (Vector3 position, Quaternion rotation)?> OnRequestSpawnPosition;
 
         private void Awake()
         {
@@ -106,7 +113,13 @@ namespace PurrNet
 
             CleanupSpawnPoints();
 
-            if (spawnPoints.Count > 0)
+            (Vector3 pos, Quaternion rot)? customSpawn = OnRequestSpawnPosition?.Invoke(player, scene, asServer);
+            if (customSpawn.HasValue)
+            {
+                var (position, rotation) = customSpawn.Value;
+                newPlayer = UnityProxy.Instantiate(_playerPrefab, position, rotation, unityScene);
+            }
+            else if (spawnPoints.Count > 0)
             {
                 var spawnPoint = spawnPoints[_currentSpawnPoint];
                 _currentSpawnPoint = (_currentSpawnPoint + 1) % spawnPoints.Count;


### PR DESCRIPTION
Currently, the PlayerSpawner requires predefined transforms to represent each player’s spawn point. This approach is rigid and limits flexibility for custom projects. For example, in an MMORPG, I load player positions from a database and would like to set the spawn position dynamically instead of relying on predefined transforms. Additionally, I need the ability to perform collision checks before spawning.

At present, this is not possible.

Suggested Improvement:
Add an event to the PlayerSpawner class that returns the spawn position.
If an event is subscribed, use its result to determine the position.
If no event is subscribed, fall back to the current behavior.

This change would enable dynamic, project-specific control over spawn locations while maintaining backwards compatibility.
I attached the code already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now specify a custom spawn position and orientation for players when they enter a scene. If none is provided, existing spawn points are used, with a safe fallback to the current location.
  * Custom spawns are prioritized, enabling finer control for modes like tutorials or re-entry scenarios.
  * Existing setups continue to work unchanged, including spawn point cycling and server-hosted sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->