### PR TITLE
Exposing peer info

### DIFF
--- a/Assets/PurrNet/Runtime/Transports/PeerInfo.cs
+++ b/Assets/PurrNet/Runtime/Transports/PeerInfo.cs
@@ -1,0 +1,24 @@
+using LiteNetLib;
+using System.Net;
+
+namespace PurrNet.Transports
+{
+  public class PeerInfo
+  {
+    public IPAddress Address { get; set; }
+
+    public int Port { get; set; }
+
+    public int Id { get; set; }
+
+    static public PeerInfo Generate(NetPeer fromNetPeer)
+    {
+      return new PeerInfo()
+      {
+        Address = fromNetPeer.Address,
+        Port = fromNetPeer.Port,
+        Id = fromNetPeer.Id
+      };
+    }
+  }
+}

--- a/Assets/PurrNet/Runtime/Transports/UDPTransport.cs
+++ b/Assets/PurrNet/Runtime/Transports/UDPTransport.cs
@@ -181,10 +181,7 @@ namespace PurrNet.Transports
             {
                 if (_connections[i] == conn)
                 {
-                    if (_peers.ContainsKey(conn))
-                    {
-                        _peers.Remove(conn);
-                    }
+                    _peers.Remove(conn);
                     _connections.RemoveAt(i);
                     break;
                 }
@@ -198,7 +195,7 @@ namespace PurrNet.Transports
         {
             var conn = new Connection(peer.Id);
 
-            _peers.Add(conn, PeerInfo.Generate(peer));
+            _peers[conn] = PeerInfo.Generate(peer);
 	  
             _connections.Add(conn);
             onConnected?.Invoke(conn, true);

--- a/Assets/PurrNet/Runtime/Transports/UDPTransport.cs
+++ b/Assets/PurrNet/Runtime/Transports/UDPTransport.cs
@@ -56,6 +56,8 @@ namespace PurrNet.Transports
 
         public IReadOnlyList<Connection> connections => _connections;
 
+        public IReadOnlyDictionary<Connection, PeerInfo> peers => _peers;
+
         private EventBasedNetListener _clientListener;
         private EventBasedNetListener _serverListener;
 
@@ -67,6 +69,8 @@ namespace PurrNet.Transports
         public ConnectionState listenerState { get; private set; } = ConnectionState.Disconnected;
 
         readonly List<Connection> _connections = new List<Connection>();
+
+        readonly Dictionary<Connection, PeerInfo> _peers = new Dictionary<Connection, PeerInfo>();
 
         public override bool isSupported => Application.platform != RuntimePlatform.WebGLPlayer;
 
@@ -177,6 +181,10 @@ namespace PurrNet.Transports
             {
                 if (_connections[i] == conn)
                 {
+                    if (_peers.ContainsKey(conn))
+                    {
+                        _peers.Remove(conn);
+                    }
                     _connections.RemoveAt(i);
                     break;
                 }
@@ -189,6 +197,9 @@ namespace PurrNet.Transports
         private void OnServerConnected(NetPeer peer)
         {
             var conn = new Connection(peer.Id);
+
+            _peers.Add(conn, PeerInfo.Generate(peer));
+	  
             _connections.Add(conn);
             onConnected?.Invoke(conn, true);
         }
@@ -298,6 +309,7 @@ namespace PurrNet.Transports
                 listenerState = ConnectionState.Disconnected;
                 TriggerConnectionStateEvent(true);
 
+                _peers.Clear();
                 _connections.Clear();
             }
         }
@@ -364,6 +376,7 @@ namespace PurrNet.Transports
             TriggerConnectionStateEvent(true);
             TriggerConnectionStateEvent(false);
 
+            _peers.Clear();
             _connections.Clear();
         }
 


### PR DESCRIPTION
Adding a new class to expose some information about the connected peer. The new class only contains what we want to expose instead of providing the whole NetPeer. It is generic enough that it can be added to, and reused for other transport types if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only access to detailed info for active network peers (address, port, identifier).
  * Peer data updates automatically on connection and disconnection events, keeping displays and diagnostics current.
  * Peer list is cleared during stop and cleanup operations to ensure consistent, accurate connection state and avoid stale entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->