### PR TITLE
Bugfix/scene cleanup mode fixes

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkRules.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkRules.cs
@@ -9,19 +9,19 @@ namespace PurrNet
     public enum SceneCleanupMode
     {
         /// <summary>
-        /// Do not cleanup any scenes on disconnect.
+        /// Do not cleanup any scenes or reload the starting scene on disconnect.
         /// </summary>
         Off,
 
         /// <summary>
-        /// Cleanup scenes that were loaded through the network, and load the starting scene additively.
+        /// Cleanup scenes that were loaded through the network, and reload the starting scene additively.
         /// </summary>
-        OnlineScenesOnly,
+        OnlineOnly,
 
         /// <summary>
-        /// Cleanup all scenes and load the start scene in single mode.
+        /// Cleanup all scenes and reload the starting scene in single mode.
         /// </summary>
-        AllScenes
+        All
     }
 
     [Serializable]
@@ -87,7 +87,7 @@ namespace PurrNet
 
         public bool removePlayerFromSceneOnDisconnect;
 
-        [Tooltip("On disconnect, unload scenes based on the cleanup mode and load the starting scene")]
+        [Tooltip("On disconnect, unload scenes and reload the starting scene based on the selected cleanup mode")]
         public SceneCleanupMode sceneCleanupModeOnDisconnect;
 
         public bool alwaysIncludeDontDestroyOnLoadScene;
@@ -95,8 +95,8 @@ namespace PurrNet
         [Obsolete("Use sceneCleanupModeOnDisconnect instead.")]
         public bool cleanupScenesOnDisconnect
         {
-            readonly get => sceneCleanupModeOnDisconnect == SceneCleanupMode.OnlineScenesOnly;
-            set => sceneCleanupModeOnDisconnect = value ? SceneCleanupMode.OnlineScenesOnly : SceneCleanupMode.Off;
+            readonly get => sceneCleanupModeOnDisconnect == SceneCleanupMode.OnlineOnly;
+            set => sceneCleanupModeOnDisconnect = value ? SceneCleanupMode.OnlineOnly : SceneCleanupMode.Off;
         }
 
         public readonly void OnBeforeSerialize()
@@ -106,9 +106,9 @@ namespace PurrNet
 
         public void OnAfterDeserialize()
         {
-            if (_cleanupScenesOnDisconnect && sceneCleanupModeOnDisconnect != SceneCleanupMode.OnlineScenesOnly)
+            if (_cleanupScenesOnDisconnect && sceneCleanupModeOnDisconnect != SceneCleanupMode.OnlineOnly)
             {
-                sceneCleanupModeOnDisconnect = SceneCleanupMode.OnlineScenesOnly;
+                sceneCleanupModeOnDisconnect = SceneCleanupMode.OnlineOnly;
                 _cleanupScenesOnDisconnect = false;
             }
         }
@@ -172,7 +172,7 @@ namespace PurrNet
         private NetworkSceneRules _defaultSceneRules = new NetworkSceneRules
         {
             removePlayerFromSceneOnDisconnect = false,
-            sceneCleanupModeOnDisconnect = SceneCleanupMode.OnlineScenesOnly,
+            sceneCleanupModeOnDisconnect = SceneCleanupMode.OnlineOnly,
             alwaysIncludeDontDestroyOnLoadScene = false
         };
 

--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -889,7 +889,7 @@ namespace PurrNet.Modules
             {
                 case CleanupStage.None:
                     {
-                        if (rules.SceneCleanupModeOnDisconnect() == SceneCleanupMode.AllScenes)
+                        if (rules.SceneCleanupModeOnDisconnect() == SceneCleanupMode.All)
                         {
                             if (_networkManager.originalSceneBuildIndex == -1)
                             {
@@ -979,6 +979,10 @@ namespace PurrNet.Modules
                         if (_ogSceneLoad is { isDone: true })
                         {
                             _scenes.Clear();
+
+                            if (_networkManager.TryGetModule(!_asServer, out ScenesModule module))
+                                module._cleanupStage = CleanupStage.Done;
+
                             _cleanupStage = CleanupStage.Done;
                         }
 

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -1168,7 +1168,7 @@ namespace PurrNet
             if (clientConnected)
                 _clientModules.TriggerOnPreFixedUpdate();
 
-            if (_transport && (serverConnected || clientConnected))
+            if (_transport)
                 _transport.transport.ReceiveMessages(delta);
 
             if (serverConnected)
@@ -1183,7 +1183,7 @@ namespace PurrNet
             if (clientConnected)
                 _clientModules.TriggerOnPostFixedUpdate();
 
-            if (_transport && (serverConnected || clientConnected))
+            if (_transport)
                 _transport.transport.SendMessages(delta);
 
             if (_isCleaningClient && _clientModules.Cleanup())

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -1168,7 +1168,7 @@ namespace PurrNet
             if (clientConnected)
                 _clientModules.TriggerOnPreFixedUpdate();
 
-            if (_transport)
+            if (_transport && (serverConnected || clientConnected))
                 _transport.transport.ReceiveMessages(delta);
 
             if (serverConnected)
@@ -1183,7 +1183,7 @@ namespace PurrNet
             if (clientConnected)
                 _clientModules.TriggerOnPostFixedUpdate();
 
-            if (_transport)
+            if (_transport && (serverConnected || clientConnected))
                 _transport.transport.SendMessages(delta);
 
             if (_isCleaningClient && _clientModules.Cleanup())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents hangs during scene cleanup by ensuring both sides complete the process reliably.
  - More robust cleanup on disconnect, improving synchronization during scene unload and original scene reload.

- Refactor
  - Renamed scene cleanup options for clarity: “OnlineScenesOnly” → “OnlineOnly” and “AllScenes” → “All”.
  - Updated related tooltips to match the new option names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->