### PR TITLE
Fix PlayerIdentity not registering players on server.

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/PlayerIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/PlayerIdentity.cs
@@ -12,9 +12,9 @@ namespace PurrNet
         {
             base.OnOwnerChanged(oldOwner, newOwner, asServer);
 
-            if (asServer && (isHost || networkManager.isPlannedHost))
+            if (asServer && isHost)
                 return;
-            
+
             if (oldOwner.HasValue)
                 _allPlayers.Remove(this as T);
 
@@ -43,7 +43,7 @@ namespace PurrNet
                 player = null;
                 return false;
             }
-            
+
             return _allPlayers.TryGetFirst(NetworkManager.main.localPlayer, out player);
         }
 
@@ -51,7 +51,7 @@ namespace PurrNet
         {
             return _allPlayers.TryGetFirst(playerId, out player);
         }
-        
+
         private sealed class FirstElementMap<TKey, T>
         {
             readonly Dictionary<TKey, List<T>> _lists = new();
@@ -99,7 +99,7 @@ namespace PurrNet
                 if (foundIndex < 0) return false;
                 return RemoveAt(foundKey, foundIndex);
             }
-            
+
             public bool RemoveKey(TKey key)
             {
                 _first.Remove(key);


### PR DESCRIPTION
The problem occurs because isPlannedHost is set to true on the server and it never changes, so it will always return before the player is registered. Minor whitespace adjustments for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted server-side ownership update logic to prevent premature skipping in non-host scenarios, ensuring more consistent player ownership changes across session roles.
  * Reduces edge-case desynchronization during ownership establishment or transitions in multiplayer sessions, improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->