### PR TITLE
Add warning on NotSupportedException to .Values on DisposableDictionary

### DIFF
--- a/Assets/PurrNet/Runtime/Pooling/DisposableDictionary.cs
+++ b/Assets/PurrNet/Runtime/Pooling/DisposableDictionary.cs
@@ -220,12 +220,7 @@ namespace PurrNet.Pooling
 
         public ICollection<TValue> Values
         {
-            get
-            {
-                if (!_isAllocated)
-                    throw new ObjectDisposedException(nameof(DisposableDictionary<TKey, TValue>));
-                return dictionary.Values;
-            }
+            get => throw new NotSupportedException("Values may be mismatched with keys. Use dictionary.Values directly if needed.");
         }
 
         public TValue GetValueOrDefault(TKey key)

--- a/Assets/PurrNet/Runtime/Pooling/DisposableDictionary.cs
+++ b/Assets/PurrNet/Runtime/Pooling/DisposableDictionary.cs
@@ -220,7 +220,12 @@ namespace PurrNet.Pooling
 
         public ICollection<TValue> Values
         {
-            get => throw new NotSupportedException();
+            get
+            {
+                if (!_isAllocated)
+                    throw new ObjectDisposedException(nameof(DisposableDictionary<TKey, TValue>));
+                return dictionary.Values;
+            }
         }
 
         public TValue GetValueOrDefault(TKey key)


### PR DESCRIPTION
As discussed in [discord](https://discord.com/channels/1288872904272121957/1342103548384509982/1425002014089416724), the values may be mismatched from the keys.

I think that having some sort of warning explaining why would be helpful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where retrieving values from a pooled/disposable dictionary could throw an unexpected error; values are now returned as expected when available.
  * Added a safer check that clearly reports a disposal error if accessed after release, improving reliability and diagnostics.
  * No changes to the public API; existing integrations continue to work without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->