### PR TITLE
Add EvaluateVisibility for specific player on server

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -522,7 +522,7 @@ namespace PurrNet
                         _serverTickManager.onTick -= ServerTick;
                 }
             }
-            else if (--_tickRegisteredClient  <= 0)
+            else if (--_tickRegisteredClient <= 0)
             {
                 if (_clientTickManager != null)
                     _clientTickManager.onTick -= ClientTick;
@@ -736,7 +736,7 @@ namespace PurrNet
         }
 
 
-        static readonly Dictionary<Type, List<MethodInfo>> _methodCache = new ();
+        static readonly Dictionary<Type, List<MethodInfo>> _methodCache = new();
 
         private void CallInitMethods()
         {
@@ -901,6 +901,20 @@ namespace PurrNet
                 return;
 
             _serverHierarchy.EvaluateVisibility(transform);
+        }
+
+        /// <summary>
+        /// Evaluates the visibility of this object for a specific player.
+        /// This will recalculate the observers of this object.
+        /// This is server specific.
+        /// Re-evaulation includes all children.
+        /// </summary>
+        public void EvaluateVisibility(PlayerID player)
+        {
+            if (isServer)
+            {
+                _serverHierarchy.EvaluateVisibility(player, base.transform);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Introduces the EvaluateVisibility(PlayerID player) method to recalculate object visibility for a given player on the server, including all children. Also includes minor formatting fixes for code consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an API to recalculate network visibility for a specific player on the server, including child objects. Enables targeted observer updates without affecting other players.
* Documentation
  * Added inline documentation describing usage, scope (server-only), and behavior of the new visibility recalculation capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->