### PR TITLE
Added Sorting wrapper method for SyncList with comparison paramenter.

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -355,7 +355,7 @@ namespace PurrNet
             if (!ValidateAuthority())
                 return;
             
-            var sorted = DisposableList<T>.Create(_list);
+            using var sorted = DisposableList<T>.Create(_list);
             sorted.list.Sort(comparison);
 
             for (int i = 0; i < sorted.Count; i++)

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -345,6 +345,56 @@ namespace PurrNet
             InvokeChange(change);
         }
 
+                /// <summary>
+        /// Sorts the list using the given comparison and syncs the changes.
+        /// </summary>
+        /// <param name="comparison">Comparison to use for sorting the list</param>
+        public void Sort(Comparison<T> comparison)
+        {
+            if (!ValidateAuthority())
+                return;
+
+            var old = new List<T>(_list);
+            var sorted = new List<T>(_list);
+            sorted.Sort(comparison);
+
+            for (int i = 0; i < sorted.Count; i++)
+                {
+                    if (i >= _list.Count || !EqualityComparer<T>.Default.Equals(_list[i], sorted[i]))
+                    {
+                        var oldValue = (i < _list.Count) ? _list[i] : default;
+
+                        if (i < _list.Count)
+                            _list[i] = sorted[i];
+                        else
+                            _list.Add(sorted[i]);
+
+                        var change = SyncListChange<T>.Set(sorted[i], oldValue, i);
+                        QueueChange(change);
+                        InvokeChange(change);
+                    }
+                }
+
+            // handle case where list was longer than sorted.
+            if (_list.Count != sorted.Count)
+            {
+                _list.Clear();
+                _list.AddRange(sorted);
+
+                var clear = SyncListChange<T>.Cleared();
+
+                QueueChange(clear);
+                InvokeChange(clear);
+
+                for (int i = 0; i < _list.Count; i++)
+                {
+                    var add = SyncListChange<T>.Added(_list[i], i);
+                    QueueChange(add);
+                    InvokeChange(add);
+                }
+            }
+        }
+
         public bool Contains(T item) => _list.Contains(item);
         public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
         public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -3,6 +3,7 @@ using PurrNet.Logging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using PurrNet.Pooling;
 using PurrNet.Transports;
 using UnityEngine.Scripting;
 
@@ -345,7 +346,7 @@ namespace PurrNet
             InvokeChange(change);
         }
 
-                /// <summary>
+        /// <summary>
         /// Sorts the list using the given comparison and syncs the changes.
         /// </summary>
         /// <param name="comparison">Comparison to use for sorting the list</param>
@@ -353,44 +354,22 @@ namespace PurrNet
         {
             if (!ValidateAuthority())
                 return;
-
-            var old = new List<T>(_list);
-            var sorted = new List<T>(_list);
-            sorted.Sort(comparison);
+            
+            var sorted = DisposableList<T>.Create(_list);
+            sorted.list.Sort(comparison);
 
             for (int i = 0; i < sorted.Count; i++)
-                {
-                    if (i >= _list.Count || !EqualityComparer<T>.Default.Equals(_list[i], sorted[i]))
-                    {
-                        var oldValue = (i < _list.Count) ? _list[i] : default;
-
-                        if (i < _list.Count)
-                            _list[i] = sorted[i];
-                        else
-                            _list.Add(sorted[i]);
-
-                        var change = SyncListChange<T>.Set(sorted[i], oldValue, i);
-                        QueueChange(change);
-                        InvokeChange(change);
-                    }
-                }
-
-            // handle case where list was longer than sorted.
-            if (_list.Count != sorted.Count)
             {
-                _list.Clear();
-                _list.AddRange(sorted);
+                T newItem = sorted[i];
+                T oldItem = _list[i];
 
-                var clear = SyncListChange<T>.Cleared();
-
-                QueueChange(clear);
-                InvokeChange(clear);
-
-                for (int i = 0; i < _list.Count; i++)
+                if (!EqualityComparer<T>.Default.Equals(oldItem, newItem))
                 {
-                    var add = SyncListChange<T>.Added(_list[i], i);
-                    QueueChange(add);
-                    InvokeChange(add);
+                    _list[i] = newItem;
+                    
+                    var change = SyncListChange<T>.Set(newItem, oldItem, i);
+                    QueueChange(change);
+                    InvokeChange(change);
                 }
             }
         }


### PR DESCRIPTION
Hi PurrNet Devs!

As mentioned on discord, I've provided the wrapper method for sorting Lists. Thought to share with you as well.
In my project seemed to have worked correctly, but feel free to test it in you environment or if you have any unit testing.

Kind Regards
Phazertron

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network-synchronized lists can now be sorted; reordering is propagated to connected instances as per-item updates.
  * Sorting checks authority/permissions before running and only reorders existing items without adding or removing entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->