### PR TITLE
Refactor: Rename `SetInt` to `SetInteger` across codebase

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetAnimatorAction.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetAnimatorAction.cs
@@ -8,7 +8,7 @@ namespace PurrNet
     {
         SetBool,
         SetFloat,
-        SetInt,
+        SetInteger,
         SetTrigger,
         SetSpeed,
         SetAnimatePhysics,
@@ -188,7 +188,7 @@ namespace PurrNet
         }
     }
 
-    internal struct SetInt : IPackedAuto
+    internal struct SetInteger : IPackedAuto
     {
         public int nameHash;
         public int value;
@@ -562,7 +562,7 @@ namespace PurrNet
 
         internal SetBool _bool;
         internal SetFloat _float;
-        internal SetInt _int;
+        internal SetInteger _integer;
         internal SetTrigger _trigger;
         private SetSpeed _speed;
         private SetAnimatePhysics _animatePhysics;
@@ -668,10 +668,10 @@ namespace PurrNet
             _float = action;
         }
 
-        public NetAnimatorRPC(SetInt action) : this()
+        public NetAnimatorRPC(SetInteger action) : this()
         {
-            type = NetAnimatorAction.SetInt;
-            _int = action;
+            type = NetAnimatorAction.SetInteger;
+            _integer = action;
         }
 
         public NetAnimatorRPC(SetTrigger action) : this()
@@ -896,7 +896,7 @@ namespace PurrNet
             {
                 case NetAnimatorAction.SetBool: _bool.Apply(anim); break;
                 case NetAnimatorAction.SetFloat: _float.Apply(anim); break;
-                case NetAnimatorAction.SetInt: _int.Apply(anim); break;
+                case NetAnimatorAction.SetInteger: _integer.Apply(anim); break;
                 case NetAnimatorAction.SetTrigger: _trigger.Apply(anim); break;
                 case NetAnimatorAction.SetSpeed: _speed.Apply(anim); break;
                 case NetAnimatorAction.SetAnimatePhysics: _animatePhysics.Apply(anim); break;
@@ -955,7 +955,7 @@ namespace PurrNet
             {
                 case NetAnimatorAction.SetBool: Packer<SetBool>.Serialize(packer, ref _bool); break;
                 case NetAnimatorAction.SetFloat: Packer<SetFloat>.Serialize(packer, ref _float); break;
-                case NetAnimatorAction.SetInt: Packer<SetInt>.Serialize(packer, ref _int); break;
+                case NetAnimatorAction.SetInteger: Packer<SetInteger>.Serialize(packer, ref _integer); break;
                 case NetAnimatorAction.SetTrigger: Packer<SetTrigger>.Serialize(packer, ref _trigger); break;
                 case NetAnimatorAction.SetSpeed: Packer<SetSpeed>.Serialize(packer, ref _speed); break;
                 case NetAnimatorAction.SetAnimatePhysics:

--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetAnimatorActionBatch.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetAnimatorActionBatch.cs
@@ -191,13 +191,13 @@ namespace PurrNet
                     }
                     case AnimatorControllerParameterType.Int:
                     {
-                        var setInt = new SetInt
+                        var setInteger = new SetInteger
                         {
                             value = animator.GetInteger(param.name),
                             nameHash = param.nameHash
                         };
 
-                        actions.Add(new NetAnimatorRPC(setInt));
+                        actions.Add(new NetAnimatorRPC(setInteger));
                         break;
                     }
                 }

--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
@@ -500,6 +500,9 @@ namespace PurrNet
 
         public bool GetBool(int nameHash) => _animator.GetBool(nameHash);
 
+        [Obsolete("Use SetInteger instead")]
+        public void SetInt(int nameHash, int value) => SetInteger(nameHash, value);
+        
         public void SetInteger(string propName, int value) => SetInteger(Animator.StringToHash(propName), value);
 
         public int GetInteger(string propName) => _animator.GetInteger(propName);

--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
@@ -500,7 +500,7 @@ namespace PurrNet
 
         public bool GetBool(int nameHash) => _animator.GetBool(nameHash);
 
-        public void SetInt(string propName, int value) => SetInt(Animator.StringToHash(propName), value);
+        public void SetInteger(string propName, int value) => SetInteger(Animator.StringToHash(propName), value);
 
         public int GetInteger(string propName) => _animator.GetInteger(propName);
 
@@ -556,17 +556,17 @@ namespace PurrNet
                 (a, b) => a._bool.nameHash == b._bool.nameHash);
         }
 
-        public void SetInt(int nameHash, int value)
+        public void SetInteger(int nameHash, int value)
         {
             if (!IsController(_ownerAuth))
                 return;
 
-            var setInt = new SetInt { nameHash = nameHash, value = value };
-            setInt.Apply(_animator);
+            var setInteger = new SetInteger { nameHash = nameHash, value = value };
+            setInteger.Apply(_animator);
             _intValues[nameHash] = value;
 
-            IfSameReplace(new NetAnimatorRPC(setInt),
-                (a, b) => a._int.nameHash == b._int.nameHash);
+            IfSameReplace(new NetAnimatorRPC(setInteger),
+                (a, b) => a._integer.nameHash == b._integer.nameHash);
         }
 
         public void Play(string stateName, int layer)

--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimatorLogic.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimatorLogic.cs
@@ -117,10 +117,10 @@ namespace PurrNet
                             => a._float.nameHash == b._float.nameHash);
                         break;
                     }
-                    case NetAnimatorAction.SetInt:
+                    case NetAnimatorAction.SetInteger:
                     {
                         RemovePast(i, action, (a, b)
-                            => a._int.nameHash == b._int.nameHash);
+                            => a._integer.nameHash == b._integer.nameHash);
                         break;
                     }
                     case NetAnimatorAction.SetTrigger:

--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimatorReflection.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimatorReflection.cs
@@ -119,16 +119,16 @@ namespace PurrNet
                         if (_intValues.TryGetValue(param.nameHash, out var v) && v == _animator.GetInteger(param.name))
                             continue;
 
-                        var setInt = new SetInt
+                        var setInteger = new SetInteger
                         {
                             value = _animator.GetInteger(param.name),
                             nameHash = param.nameHash
                         };
 
-                        _intValues[param.nameHash] = setInt.value;
+                        _intValues[param.nameHash] = setInteger.value;
 
-                        IfSameReplace(new NetAnimatorRPC(setInt),
-                            (a, b) => a._int.nameHash == b._int.nameHash);
+                        IfSameReplace(new NetAnimatorRPC(setInteger),
+                            (a, b) => a._integer.nameHash == b._integer.nameHash);
                         break;
                     }
                 }


### PR DESCRIPTION
I renamed the **SetInt** method to **SetInteger** to make them compatible with the Unity Animator implementation. This should make it easier to swap the Animator with the NetworkAnimator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed public API from SetInt to SetInteger for integer animator parameters; existing SetInt calls are preserved but marked obsolete and forwarded to the new API.
  * Added a convenience overload accepting a property name (for easier calls).
  * Behavior and networking of animator integer parameters remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->