### PR TITLE
fix: Host migration should be enabled to check if it must force scene…

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -767,7 +767,7 @@ namespace PurrNet.Modules
             if (!settings.isPublic)
             {
                 var rules = _networkManager.networkRules;
-                if (rules && rules.ShouldForceSceneToAlwaysPublic())
+                if (rules && rules.IsHostMigrationEnabled() && rules.ShouldForceSceneToAlwaysPublic())
                 {
                     PurrLogger.LogWarning("Host migration is enabled, so scenes cannot be set to private");
                     settings.isPublic = true;


### PR DESCRIPTION
… public or not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host migration compatibility by refining how scene privacy is managed. Scenes will no longer be forcibly set to public during host migration scenarios unless both host migration is enabled and additional specific conditions are met, allowing for more flexible and granular control over scene visibility in multiplayer environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->