### PR TITLE
fix: Host migration should be enabled to check if it must force CanSee or not

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkVisibility/NetworkVisibilityRuleSet.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkVisibility/NetworkVisibilityRuleSet.cs
@@ -58,7 +58,7 @@ namespace PurrNet
         public bool CanSee(PlayerID player, NetworkIdentity target)
         {
             var rules = target.networkRules;
-            if (rules && rules.ShouldForceVisibilityToAlwaysVisible())
+            if (rules && rules.IsHostMigrationEnabled() && rules.ShouldForceVisibilityToAlwaysVisible())
                 return true;
 
             for (int i = 0; i < _raw_rules.Count; i++)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified network visibility logic to enforce stricter conditions before granting visibility in networked scenarios. Additional prerequisites must now be satisfied simultaneously for visibility to be granted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->