### PR TITLE
fix: add bounds checking to BitPacker.ReadBits to prevent native crash on malformed packets

### DIFF
--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -508,8 +508,11 @@ namespace PurrNet.Packing
             if (bits > 64)
                 throw new ArgumentOutOfRangeException(nameof(bits));
 
+            EnsureBitsExist(bits);
+
             int bytePos = _positionInBits >> 3;
             int bitOffset = _positionInBits & 7;
+            int safeBytes = _buffer.Length - bytePos;
 
             ulong result;
 
@@ -517,6 +520,11 @@ namespace PurrNet.Packing
             {
                 if (bitOffset == 0)
                 {
+                    // Guard: fast paths use wide pointer reads (up to 8 bytes).
+                    // Fall back to the safe slow path when near the end of the buffer.
+                    if (safeBytes < 8)
+                        goto SlowPath;
+
                     // Fast path: byte-aligned reads
                     switch (bits)
                     {
@@ -571,6 +579,10 @@ namespace PurrNet.Packing
                 }
                 else
                 {
+                    // Guard: unaligned path reads 8 bytes via pointer
+                    if (safeBytes < 8)
+                        goto SlowPath;
+
                     // Unaligned read - read as 64-bit and extract bits
                     int totalBits = bits + bitOffset;
 

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackStrings.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackStrings.cs
@@ -23,6 +23,12 @@ namespace PurrNet.Packing
                 packer.Write(value[i]);
         }
 
+        /// <summary>
+        /// Maximum allowed string length during deserialization to guard against
+        /// corrupted or malicious packets that could cause excessive allocations.
+        /// </summary>
+        private const int MAX_STRING_LENGTH = 64 * 1024;
+
         [UsedByIL]
         public static void Read(this BitPacker packer, ref string value)
         {
@@ -39,6 +45,11 @@ namespace PurrNet.Packing
             int strLen = 0;
 
             packer.Read(ref strLen);
+
+            if (strLen < 0 || strLen > MAX_STRING_LENGTH)
+                throw new System.Runtime.Serialization.SerializationException(
+                    $"Invalid string length during deserialization: {strLen}. " +
+                    $"This likely indicates a corrupted or truncated network packet.");
 
             var chars = new char[strLen];
 


### PR DESCRIPTION
## Problem

\BitPacker.ReadBits()\ uses unsafe pointer dereferences (\*(ulong*)b\) that read 8 bytes at a time for performance. When the read position is within 7 bytes of the buffer end, this causes a **native access violation** (hard crash, not a managed exception).

This was discovered in production via a crash during \StabilityManager\ RPC deserialization, where a corrupted/truncated Steam P2P packet caused \BitPacker\ to read past the buffer boundary during string deserialization.

### Crash call chain
\\\
NetworkManager.OnDataReceived()
  → RPCModule.ReceiveRPC()
    → StabilityManager.HandleRPCGenerated_0()
      → Packer<string>.Read()
        → PackStrings.Read()
          → BitPacker.ReadBits()  ← native crash here
\\\

## Root Cause

1. **\ReadBits()\ never calls \EnsureBitsExist()\** — the method that would throw a safe managed \IndexOutOfRangeException\ already exists but is only used on write paths.
2. **Fast-path pointer reads always dereference 8 bytes** — \*(ulong*)b\ reads 8 bytes even when only 1 bit is requested. Near buffer end, this reads past the allocation.
3. **\PackStrings.Read()\ trusts the length header blindly** — a corrupted packet with a garbage string length causes unbounded allocation and repeated out-of-bounds reads.

## Changes

- **\BitPacker.cs\**: Added \EnsureBitsExist(bits)\ call at the top of \ReadBits()\. Added \safeBytes < 8\ guard before both aligned and unaligned fast paths to fall back to the safe \SlowPath\ when near the buffer boundary.
- **\PackStrings.cs\**: Added sanity check on deserialized string length (rejects negative values or lengths > 64KB) with a descriptive error message.

## Impact

- **Before**: Corrupted/truncated network packet → native access violation → **hard crash** (no exception, no recovery)
- **After**: Corrupted/truncated network packet → managed \IndexOutOfRangeException\ or \SerializationException\ → **catchable**, loggable, recoverable

23 lines added, 0 removed. No behavioral changes for valid packets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data reading safety with boundary checks near buffer limits.
  * Added validation for string deserialization to prevent handling of excessively long strings and invalid data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->