### PR TITLE
fix: buffer overflow in RPC response handling

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs
@@ -98,7 +98,7 @@ namespace PurrNet.Modules
                 {
                     _requests.RemoveAt(i);
 
-                    using var stream = RPCModule.AllocStream(true);
+                    using var stream = RPCModule.AllocStream(false);
                     stream.WriteBytes(data.data);
                     stream.ResetPosition();
 


### PR DESCRIPTION
## Problem

IndexOutOfRangeException "Not enough bits in the buffer" occurring when processing big RPC responses. This only happens *sometimes*, and I unfortunately don't have a 1-2-3 reproduction path.

The full stack trace for one instance:

```
IndexOutOfRangeException: Not enough bits in the buffer. | 15712 > 8192
PurrNet.Packing.BitPacker.EnsureBitsExist (System.Int32 bits) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/BitPacker/BitPacker.cs:224)
PurrNet.Packing.BitPacker.WriteBytes (System.ReadOnlySpan`1[T] bytes) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/BitPacker/BitPacker.cs:651)
PurrNet.Packing.BitPacker.WriteBytes (PurrNet.Transports.ByteData byteData) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/BitPacker/BitPacker.cs:630)
PurrNet.Modules.RpcRequestResponseModule.OnRpcResponse (PurrNet.PlayerID conn, PurrNet.Modules.RpcResponse data, System.Boolean asServer) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/RPCs/RpcRequestResponseModule.cs:69)
PurrNet.PlayerBroadcastCallback`1[T].TriggerCallback (PurrNet.PlayerID playerId, System.Object data, System.Boolean asServer) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/Players/PlayersBroadcaster.cs:34)
PurrNet.PlayersBroadcaster.OnRawDataReceived (PurrNet.Transports.Connection conn, System.UInt32 hash, System.Object data) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/Players/PlayersBroadcaster.cs:70)
PurrNet.Modules.BroadcastModule.TriggerCallback (PurrNet.Transports.Connection conn, System.UInt32 hash, System.Object instance) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/Broadcast/BroadcastModule.cs:224)
PurrNet.Modules.BroadcastModule.OnDataReceived (PurrNet.Transports.Connection conn, PurrNet.Transports.ByteData data, System.Boolean asServer) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/Broadcast/BroadcastModule.cs:174)
PurrNet.ModulesCollection.OnDataReceived (PurrNet.Transports.Connection conn, PurrNet.Transports.ByteData data, System.Boolean asServer) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Managers/ModulesCollection.cs:120)
PurrNet.NetworkManager.OnDataReceived (PurrNet.Transports.Connection conn, PurrNet.Transports.ByteData data, System.Boolean asServer) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Managers/NetworkManager.cs:1531)
PurrNet.Transports.UDPTransport.OnClientData (LiteNetLib.NetPeer peer, LiteNetLib.NetPacketReader reader, System.Byte channel, LiteNetLib.DeliveryMethod deliverymethod) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Transports/UDPTransport.cs:159)
LiteNetLib.EventBasedNetListener.LiteNetLib.INetEventListener.OnNetworkReceive (LiteNetLib.NetPeer peer, LiteNetLib.NetPacketReader reader, System.Byte channelNumber, LiteNetLib.DeliveryMethod deliveryMethod) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/INetEventListener.cs:247)
LiteNetLib.NetManager.ProcessEvent (LiteNetLib.NetEvent evt) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.cs:494)
LiteNetLib.NetManager.CreateReceiveEvent (LiteNetLib.NetPacket packet, LiteNetLib.DeliveryMethod method, System.Byte channelNumber, System.Int32 headerSize, LiteNetLib.NetPeer fromPeer) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.cs:1069)
LiteNetLib.NetPeer.AddReliablePacket (LiteNetLib.DeliveryMethod method, LiteNetLib.NetPacket p) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetPeer.cs:1048)
LiteNetLib.ReliableChannel.ProcessPacket (LiteNetLib.NetPacket packet) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/ReliableChannel.cs:304)
LiteNetLib.NetPeer.ProcessPacket (LiteNetLib.NetPacket packet) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetPeer.cs:1282)
LiteNetLib.NetPeer.ProcessPacket (LiteNetLib.NetPacket packet) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetPeer.cs:1236)
LiteNetLib.NetManager.DebugMessageReceived (LiteNetLib.NetPacket packet, System.Net.IPEndPoint remoteEndPoint) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.cs:1040)
LiteNetLib.NetManager.OnMessageReceived (LiteNetLib.NetPacket packet, System.Net.IPEndPoint remoteEndPoint) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.cs:837)
LiteNetLib.NetManager.ReceiveFrom (System.Net.Sockets.Socket s, System.Net.EndPoint& bufferEndPoint) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.Socket.cs:261)
LiteNetLib.NetManager.ManualReceive (System.Net.Sockets.Socket socket, System.Net.EndPoint bufferEndPoint, System.Int32 maxReceive) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.Socket.cs:102)
UnityEngine.Debug:LogException(Exception)
LiteNetLib.NetManager:ManualReceive(Socket, EndPoint, Int32) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.Socket.cs:118)
LiteNetLib.NetManager:PollEvents(Int32) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Externals/LiteNetLib/NetManager.cs:1476)
PurrNet.Transports.UDPTransport:ReceiveMessages(Single) (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Transports/UDPTransport.cs:236)
PurrNet.NetworkManager:OnTick() (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Managers/NetworkManager.cs:1241)
PurrNet.NetworkManager:OnClientTick() (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Managers/NetworkManager.cs:1166)
PurrNet.Modules.TickManager:HandleTick() (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/Ticks/TickManager.cs:143)
PurrNet.Modules.TickManager:Update() (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/CoreModules/Ticks/TickManager.cs:107)
PurrNet.ModulesCollection:TriggerOnUpdate() (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Managers/ModulesCollection.cs:126)
PurrNet.NetworkManager:Update() (at ./Library/PackageCache/dev.purrnet.purrnet@b77139d632e6/Runtime/Managers/NetworkManager.cs:1210)
```


## Suspected Root Cause

Line 101 in `OnRpcResponse` allocates a readonly buffer with `AllocStream(true)`, then immediately writes response data to it:

```csharp
using var stream = RPCModule.AllocStream(true);  // readonly = true
stream.WriteBytes(data.data);  // writing to it
```

The true parameter indicates readonly, which appears to allocate a fixed-size buffer. Writing response data that exceeds this fixed size would cause the buffer overflow. 

The code also *seems* contradictory - requesting a readonly buffer and then immediately writing to it.

## Proposed Solution

Changed AllocStream(true) to AllocStream(false). The false parameter should allocate a writable buffer sized for the actual data being written.

This also makes the code consistent with every other AllocStream usage in this file, which all use AllocStream(false) followed by write operations.

## Testing

Manual testing shows the issue appears to be resolved - I haven't seen the bug occur since making this change, after some extensive manual testing. However, I'm not 100% certain because I don't have a watertight reproduction path. The bug happened intermittently before, so it's hard to definitively confirm it's fixed. Open to discussion if there's a deeper issue at play.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Optimization**
  * Adjusted stream allocation behavior in network RPC request-response handling to optimize resource utilization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->