### PR TITLE
fix: scene module events not firing

### DIFF
--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -1338,6 +1338,7 @@ namespace PurrNet
                 {
                     _clientModules.UnregisterModules();
                     CleanupClientModules();
+                    TriggerUnsubscribeEvents(false);
                     _isCleaningClient = false;
                 }
             }
@@ -1347,6 +1348,7 @@ namespace PurrNet
                 _isServerTicking = false;
                 _serverModules.UnregisterModules();
                 CleanupServerModules();
+                TriggerUnsubscribeEvents(true);
                 _isCleaningServer = false;
             }
 


### PR DESCRIPTION
# Problem

When a client fails to connect once, and after that succesfully connects, scene module events (`OnSceneLoaded`, `OnPreSceneLoaded`, others?) are not fired.

# Reproduction

## Setup
I have an example project right here:
[scene_module_events_not_firing.zip](https://github.com/user-attachments/files/25090117/scene_module_events_not_firing.zip)

It is just a new project with: latest PurrNet release (v.1.18), Multiplayer Play Mode. I added NetworkManager with UDP Transport, and disabled autostart stuff.

I have also added the following component to it:

```cs
public class SceneModuleEventsExample : MonoBehaviour
{
    [SerializeField]
    private NetworkManager networkManager;

    private void Start()
    {
        this.networkManager.onNetworkStartedSimple += this.OnNetworkManagerOnonNetworkStartedSimple;
    }

    private void OnNetworkManagerOnonNetworkStartedSimple(NetworkManager _)
    {
        this.networkManager.sceneModule.onSceneLoaded += this.SceneModuleOnonSceneLoaded;
        this.networkManager.sceneModule.onPreSceneLoaded += this.OnPreSceneLoaded;
    }

    private void OnPreSceneLoaded(SceneID scene, bool asServer)
    {
        Debug.Log("OnPreSceneLoaded");
    }

    private async void SceneModuleOnonSceneLoaded(SceneID scene, bool asServer)
    {
        Debug.Log("SceneModuelOnonSceneLoaded");
    }
}
```

## Repro path

### Happy path
1: Start two instances
2: Click "Start Server" in one:
  
<img width="237" height="73" alt="image" src="https://github.com/user-attachments/assets/10771af4-d560-4b9a-8174-dd326ea5028f" />

3: Click "Start Client" in the other
<img width="254" height="66" alt="image" src="https://github.com/user-attachments/assets/9a837692-1ff9-4ccc-ae38-8b2b99754b15" />

4: Events are fired and logged

<img width="343" height="117" alt="image" src="https://github.com/user-attachments/assets/4d8e115e-13c1-40bc-9a83-47debdc0a10d" />


### Bug path
1: Start two instances
2: Click "Start **Client**" first in one, wait until it fails
<img width="273" height="70" alt="image" src="https://github.com/user-attachments/assets/f511a4ed-67df-400d-8773-f5e9685a46cb" />
3: Click "Start Server" in the _other_
4: Click "Start Client" in the first one, it now connects correctly:
<img width="247" height="69" alt="image" src="https://github.com/user-attachments/assets/5a52da53-e793-4f71-8646-7e941b611be7" />
5: But the console does **not** show any logged events, they are not fired:
<img width="340" height="151" alt="image" src="https://github.com/user-attachments/assets/b890c692-b204-4202-8c46-97b96dac78f0" />

# Applied Fix
During client and server cleanup: `TriggerUnsubscribeEvents` manually. This does some cleanup to start fresh on the next connection attempt. This fixes at least this instance of the bug, and makes sure those events are correctly fired after a failed connection attempt.

However; **I'm not sure this is the right location and/or way of doing this!**

# Doubts about fix
`TriggerUnsubscribeEvents` in `NetworkManager` is at this moment only called by `InternalUnregister(Client|Server)Modules`. The only place that's called is by the `GenericTransport`'s `internal` `StopClient` method. 

`StopClient` does not necessarily seem to be the right call to make, or should that call be done? Is it then subscribed?

Should we instead call `InternalUnregisterClientModules` from the cleanup path?

Or should `InternalUnregisterClientModules` somehow be called by the already existing code, namely the `_clientModules.UnregisterModules();` call two lines higher?

Or should it be called in `CleanupClientModules();` one line higher?

They all seem to have to do with cleaning up and unregistering; so I'm just putting the problem statement, reproduction path with project and something that at least fixes it here in the hopes of getting feedback and/or discussion on where this should be called, or what other approach to take.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network cleanup reliability by ensuring proper event signaling during client and server connection teardown procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->