### PR TITLE
Fix order of client state change.

### DIFF
--- a/Assets/PurrNet/Addons/UTP/Runtime/UTPTransport.cs
+++ b/Assets/PurrNet/Addons/UTP/Runtime/UTPTransport.cs
@@ -386,13 +386,16 @@ namespace PurrNet.UTP
         
         private void OnClientStateChanged(ConnectionState state)
         {
+			// Update clientState BEFORE firing events to prevent race condition
+    		// where authentication tries to send before clientState is updated
+    		clientState = state;
+
             if (state == ConnectionState.Connected)
                 onConnected?.Invoke(new Connection(0), false);
 
             if (state == ConnectionState.Disconnected)
                 onDisconnected?.Invoke(new Connection(0), DisconnectReason.ClientRequest, false);
-
-            clientState = state;
+			
         }
         
         /// <summary>


### PR DESCRIPTION
There was some small problem of the order things went so I fixed that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a race condition in client connection state handling that could cause the connection status to appear outdated during state transitions, ensuring more reliable state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->