### PR TITLE
I forgot this change to the Ip to bind to in Unity Lobby Mode

### DIFF
--- a/Assets/PurrNet/Addons/UTP/Runtime/UTPServer.cs
+++ b/Assets/PurrNet/Addons/UTP/Runtime/UTPServer.cs
@@ -95,7 +95,8 @@ namespace PurrNet.UTP
             NetworkEndpoint endpoint;
             if (relayData.HasValue)
             {
-                endpoint = relayData.Value.Endpoint;
+                // When using Unity Relay, bind to 0.0.0.0:0 (AnyIpv4)
+				endpoint = NetworkEndpoint.AnyIpv4;
             }
             else
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified network endpoint binding behavior when relay data is provided. The server now binds to all available IPv4 interfaces instead of using the relay-provided endpoint, improving network accessibility and connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->