### PR TITLE
Add Steam ID lookup for player connections

### DIFF
--- a/Assets/PurrNet/Addons/Steam/Runtime/PurrSteamUtils.cs
+++ b/Assets/PurrNet/Addons/Steam/Runtime/PurrSteamUtils.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using JetBrains.Annotations;
 using PurrNet.Logging;
+using PurrNet.Modules;
 
 namespace PurrNet.Steam
 {
@@ -23,6 +24,29 @@ namespace PurrNet.Steam
             }
 
             return 0;
+        }
+        
+        public static bool TryGetSteamID(PlayerID playerID, out ulong steamID)
+        {
+            steamID = default;
+
+            var networkManager = NetworkManager.main;
+            if (networkManager == null)
+                return false;
+
+            bool asServer = networkManager.isServer;
+
+            if (networkManager.TryGetModule<PlayersManager>(asServer, out var playersManager) &&
+                playersManager.TryGetConnection(playerID, out var connection))
+            {
+                if (networkManager.transport is SteamTransport steamTransport)
+                {
+                    steamID = steamTransport.GetSteamID(connection);
+                    return steamID != 0;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Assets/PurrNet/Addons/Steam/Runtime/SteamServer.cs
+++ b/Assets/PurrNet/Addons/Steam/Runtime/SteamServer.cs
@@ -34,6 +34,7 @@ namespace PurrNet.Steam
  new Dictionary<int, HSteamNetConnection>();
         private readonly Dictionary<HSteamNetConnection, int> _idByConnection =
  new Dictionary<HSteamNetConnection, int>();
+        private readonly Dictionary<int, ulong> _steamIdByConnection = new Dictionary<int, ulong>();
 
         readonly IntPtr[] _messages = new IntPtr[MAX_MESSAGES];
 #endif
@@ -181,6 +182,15 @@ namespace PurrNet.Steam
             else SteamNetworkingSockets.CloseConnection(conn, 0, null, false);
 #endif
         }
+        
+        public ulong GetSteamID(int connectionId)
+        {
+#if STEAMWORKS_NET_PACKAGE && !DISABLESTEAMWORKS
+            if (_steamIdByConnection.TryGetValue(connectionId, out var steamID))
+                return steamID;
+#endif
+            return 0;
+        }
 
 #if STEAMWORKS_NET_PACKAGE && !DISABLESTEAMWORKS
         private static void MakeSureBufferCanFit(int packetLength)
@@ -227,12 +237,13 @@ namespace PurrNet.Steam
 #if STEAMWORKS_NET_PACKAGE && !DISABLESTEAMWORKS
         private int _nextConnectionId;
 
-        private void AddConnection(HSteamNetConnection connection)
+        private void AddConnection(HSteamNetConnection connection, ulong steamId)
         {
             int id = _nextConnectionId++;
             _connections.Add(connection);
             _connectionById.Add(id, connection);
             _idByConnection.Add(connection, id);
+            _steamIdByConnection.Add(id, steamId);
 
             onRemoteConnected?.Invoke(id);
         }
@@ -243,6 +254,7 @@ namespace PurrNet.Steam
             {
                 _connectionById.Remove(_id);
                 onRemoteDisconnected?.Invoke(_id);
+                _steamIdByConnection.Remove(_id);
             }
         }
 
@@ -267,7 +279,7 @@ namespace PurrNet.Steam
                 }
                 case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected:
                 {
-                    AddConnection(args.m_hConn);
+                    AddConnection(args.m_hConn, args.m_info.m_identityRemote.GetSteamID64());
                     break;
                 }
                 default:
@@ -309,6 +321,7 @@ namespace PurrNet.Steam
             _connections.Clear();
             _connectionById.Clear();
             _idByConnection.Clear();
+            _steamIdByConnection.Clear();
 
             try
             {

--- a/Assets/PurrNet/Addons/Steam/Runtime/SteamTransport.cs
+++ b/Assets/PurrNet/Addons/Steam/Runtime/SteamTransport.cs
@@ -279,5 +279,10 @@ namespace PurrNet.Steam
             _server?.SendMessages();
             _client?.SendMessages();
         }
+        
+        public ulong GetSteamID(Connection conn)
+        {
+            return _server?.GetSteamID(conn.connectionId) ?? 0;
+        }
     }
 }


### PR DESCRIPTION
Get a player's Steam ID from their PlayerID when using SteamTransport
 (coderabbit can explain better than I ever could lol)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Steam ID lookup and tracking for connected players, enabling the network system to identify and retrieve Steam identifiers during multiplayer sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->