### PR TITLE
feat: add SetAnimator method to NetworkAnimator for improved animator…

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
@@ -48,6 +48,24 @@ namespace PurrNet
         /// </summary>
         public Animator animator => _animator;
 
+        public void SetAnimator(Animator animator)
+        {
+            _animator = animator;
+            _avatarRoot = null;
+            _dontSyncHashes.Clear();
+            for (var i = 0; i < _dontSyncParameters.Count; i++)
+                _dontSyncHashes.Add(Animator.StringToHash(_dontSyncParameters[i]));
+            if (_animator != null)
+            {
+                for (var i = 0; i < _animator.parameters.Length; i++)
+                {
+                    var parameter = _animator.parameters[i];
+                    if (_animator.IsParameterControlledByCurve(parameter.nameHash))
+                        _dontSyncHashes.Add(parameter.nameHash);
+                }
+            }
+        }
+
         public List<string> dontSyncParameters => _dontSyncParameters;
 
         private void Awake()

--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
@@ -48,6 +48,12 @@ namespace PurrNet
         /// </summary>
         public Animator animator => _animator;
 
+        /// <summary>
+        /// Sets the animator to sync and rebuilds internal state (avatar root cache, dont-sync parameter hashes).
+        /// </summary>
+        /// <param name="animator">The animator to sync. Can be null.</param>
+        /// <remarks>Use this when switching animators at runtime (e.g. after spawning, pooling, or model swap).</remarks>
+        [PurrDocs("systems-and-modules/plug-n-play-components/network-animator")]
         public void SetAnimator(Animator animator)
         {
             _animator = animator;


### PR DESCRIPTION
# Summary
Adds a `SetAnimator` method to `NetworkAnimator` to allow changing the associated `Animator` reference at runtime.

This removes the previous limitation where the animator could only be assigned via the Inspector and enables dynamic reassignment during gameplay.

---

# Changes

## Added
### `SetAnimator(Animator animator)`
- Assigns a new `Animator` instance.
- Clears cached `_avatarRoot` so it is recomputed from the new animator.
- Rebuilds `_dontSyncHashes` using:
  - `_dontSyncParameters`
  - Curve-controlled parameters from the newly assigned animator.

## Internal Behavior
- Ensures all animator-dependent cached state is refreshed.
- Prevents stale parameter hashes or avatar references when switching animators.

---

# Motivation
Previously, the animator reference was static and could only be set in the Inspector. This enhancement supports runtime workflows, including:

- Switching animators on the same object.
- Assigning animators programmatically (e.g., after spawning or object pooling).
- Replacing animators when swapping character models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime animator switching: you can now assign or replace an entity's animator during gameplay. The system updates animation ownership and exclusions automatically (including parameters driven by animation curves) and refreshes internal avatar references, enabling smoother, flexible animation updates for networked characters without restarting scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->