### PR TITLE
Add first, last and reload current to StateMachine

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -787,12 +787,13 @@ namespace PurrNet.StateMachine
         }
         
         /// <summary>
-        ///  The state machine will reload the current state
+        /// The state machine will reload the current state
+        /// This will exit the state and re-enter it
         /// </summary>
 
         public bool ReloadCurrent(bool force = false)
         {
-            return SetState(_syncedStates[currentState.stateId], force);
+            return SetState(_syncedStates[_currentState.stateId], force);
         }
         
         internal enum StateTransitionStatus

--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -682,6 +682,16 @@ namespace PurrNet.StateMachine
             return SetState(_syncedStates[^1], force);
         }
         
+        
+        /// <summary>
+        ///  The state machine will reload the current state
+        /// </summary>
+
+        public bool ReloadCurrent(bool force = false)
+        {
+            return SetState(_syncedStates[currentState.stateId], force);
+        }
+        
         /// <summary>
         /// Will continue to the previous state in the states list until it finds a state that can be entered
         /// </summary>

--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -665,34 +665,6 @@ namespace PurrNet.StateMachine
         }
         
         /// <summary>
-        /// Takes the state machine to the first state in the states list
-        /// </summary>
-
-        public bool First(bool force = false)
-        {
-            return SetState(_syncedStates[0], force);
-        }
-        
-        /// <summary>
-        /// Takes the state machine to the last state in the states list
-        /// </summary>
-
-        public bool Last(bool force = false)
-        {
-            return SetState(_syncedStates[^1], force);
-        }
-        
-        
-        /// <summary>
-        ///  The state machine will reload the current state
-        /// </summary>
-
-        public bool ReloadCurrent(bool force = false)
-        {
-            return SetState(_syncedStates[currentState.stateId], force);
-        }
-        
-        /// <summary>
         /// Will continue to the previous state in the states list until it finds a state that can be entered
         /// </summary>
         public bool PreviousValid()
@@ -770,6 +742,34 @@ namespace PurrNet.StateMachine
             if (prevNodeId < 0)
                 prevNodeId = _syncedStates.Count - 1;
             return prevNodeId;
+        }
+        
+        /// <summary>
+        /// Takes the state machine to the first state in the states list
+        /// </summary>
+
+        public bool First(bool force = false)
+        {
+            return SetState(_syncedStates[0], force);
+        }
+        
+        /// <summary>
+        /// Takes the state machine to the last state in the states list
+        /// </summary>
+
+        public bool Last(bool force = false)
+        {
+            return SetState(_syncedStates[^1], force);
+        }
+        
+        
+        /// <summary>
+        ///  The state machine will reload the current state
+        /// </summary>
+
+        public bool ReloadCurrent(bool force = false)
+        {
+            return SetState(_syncedStates[currentState.stateId], force);
         }
         
         internal enum StateTransitionStatus

--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -753,6 +753,18 @@ namespace PurrNet.StateMachine
             return SetState(_syncedStates[0], force);
         }
         
+        public bool First<T>(T data, bool force = false)
+        {
+            var firstNode = _syncedStates[0];
+            if (firstNode is StateNode<T> stateNode)
+            {
+                return SetState(stateNode, data, force);
+            }
+            
+            PurrLogger.LogException($"Node {_syncedStates[0].name}:{_syncedStates[0].GetType().Name} does not have a generic type argument of type {typeof(T).Name}");
+            return false;
+        }
+        
         /// <summary>
         /// Takes the state machine to the last state in the states list
         /// </summary>
@@ -762,6 +774,17 @@ namespace PurrNet.StateMachine
             return SetState(_syncedStates[^1], force);
         }
         
+        public bool Last<T>(T data, bool force = false)
+        {
+            var lastNode = _syncedStates[^1];
+            if (lastNode is StateNode<T> stateNode)
+            {
+                return SetState(stateNode, data, force);
+            }
+            
+            PurrLogger.LogException($"Node {_syncedStates[0].name}:{_syncedStates[0].GetType().Name} does not have a generic type argument of type {typeof(T).Name}");
+            return false;
+        }
         
         /// <summary>
         ///  The state machine will reload the current state

--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -796,6 +796,16 @@ namespace PurrNet.StateMachine
             return SetState(_syncedStates[_currentState.stateId], force);
         }
         
+        public bool ReloadCurrent<T>(T data, bool force = false)
+        {
+            if (currentStateNode is StateNode<T> stateNode)
+            {
+                return SetState(stateNode, data, force);
+            }
+            PurrLogger.LogException($"Node {currentStateNode.name}:{currentStateNode.GetType().Name} does not have a generic type argument of type {typeof(T).Name}");
+            return false;
+        }
+        
         internal enum StateTransitionStatus
         {
             Success,

--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -747,7 +747,6 @@ namespace PurrNet.StateMachine
         /// <summary>
         /// Takes the state machine to the first state in the states list
         /// </summary>
-
         public bool First(bool force = false)
         {
             return SetState(_syncedStates[0], force);
@@ -768,7 +767,6 @@ namespace PurrNet.StateMachine
         /// <summary>
         /// Takes the state machine to the last state in the states list
         /// </summary>
-
         public bool Last(bool force = false)
         {
             return SetState(_syncedStates[^1], force);
@@ -790,7 +788,6 @@ namespace PurrNet.StateMachine
         /// The state machine will reload the current state
         /// This will exit the state and re-enter it
         /// </summary>
-
         public bool ReloadCurrent(bool force = false)
         {
             return SetState(_syncedStates[_currentState.stateId], force);

--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -665,6 +665,24 @@ namespace PurrNet.StateMachine
         }
         
         /// <summary>
+        /// Takes the state machine to the first state in the states list
+        /// </summary>
+
+        public bool First(bool force = false)
+        {
+            return SetState(_syncedStates[0], force);
+        }
+        
+        /// <summary>
+        /// Takes the state machine to the last state in the states list
+        /// </summary>
+
+        public bool Last(bool force = false)
+        {
+            return SetState(_syncedStates[^1], force);
+        }
+        
+        /// <summary>
         /// Will continue to the previous state in the states list until it finds a state that can be entered
         /// </summary>
         public bool PreviousValid()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added state machine navigation helpers to move to the first or last state, and to reload the current state.
  * Optional "force" parameter to bypass transition checks when changing or reloading states.
  * Support for passing data along with state transitions via typed method variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->