### PR TITLE
Public read-only SpawnPoints getter in PlayerSpawner

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/PlayerSpawner.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/PlayerSpawner.cs
@@ -30,6 +30,7 @@ namespace PurrNet
         [SerializeField] private bool _ignoreNetworkRules;
 
         [SerializeField] private List<Transform> spawnPoints = new List<Transform>();
+        public IReadOnlyList<Transform> SpawnPoints => spawnPoints;
         private int _currentSpawnPoint;
 
         private IProvideSpawnPoints _spawnPointProvider;


### PR DESCRIPTION
Added an IReadOnlyList to expose the PlayerSpawner spawn points to other scripts.

This is useful for building a quick respawn system without having to declare or duplicate spawn point references multiple times, since they can now be accessed directly from the same source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public read-only access to spawn points, allowing external systems to safely retrieve the spawn point collection while maintaining data integrity and preventing unauthorized modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->