### PR TITLE
Fix SyncVar crash when parent is destroyed during despawn

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -164,12 +164,15 @@ namespace PurrNet
         {
             InvalidateIsController();
 
-            if (isControllingSyncVar)
+            if (isControllingSyncVar && parent)
             {
                 _id += 1;
-                FlushImmediately();
+                ForceSendReliable();
+                _lastSendTime = Time.time;
             }
 
+            _wasLastDirty = false;
+            _isDirty = false;
             UnsubscribeFromTickManager();
         }
 
@@ -209,7 +212,7 @@ namespace PurrNet
 
         public void OnTick()
         {
-            if (!isControllingSyncVar)
+            if (!isControllingSyncVar || !parent)
             {
                 UnsubscribeFromTickManager();
                 return;

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -164,16 +164,21 @@ namespace PurrNet
         {
             InvalidateIsController();
 
-            if (isControllingSyncVar && parent)
+            try
             {
-                _id += 1;
-                ForceSendReliable();
-                _lastSendTime = Time.time;
+                if (isControllingSyncVar && parent)
+                {
+                    _id += 1;
+                    ForceSendReliable();
+                    _lastSendTime = Time.time;
+                }
             }
-
-            _wasLastDirty = false;
-            _isDirty = false;
-            UnsubscribeFromTickManager();
+            finally
+            {
+                _wasLastDirty = false;
+                _isDirty = false;
+                UnsubscribeFromTickManager();
+            }
         }
 
         public void SetDirty()


### PR DESCRIPTION
## Problem

When a `SyncVar`'s parent `NetworkIdentity` is destroyed, `OnDespawned()` calls `FlushImmediately()` → `ForceSendReliable()` → `BuildRPC()`. If the parent is already destroyed at this point, `BuildRPC()` throws an `InvalidOperationException` ("Trying to send RPC from 'SyncVar\`1' which is not spawned.").

This exception unwinds the stack and **skips `UnsubscribeFromTickManager()`**. The SyncVar remains subscribed to the tick manager and throws on every subsequent tick indefinitely — we observed 9,117 of these errors in a single session on a host.

### IL2CPP Native Crash

In IL2CPP builds, the repeated access to destroyed Unity objects through the native bridge progressively corrupts type metadata. This eventually leads to a **native crash** in `mono_class_has_parent` during `il2cpp_field_set_value` — a crash that bypasses Unity's managed exception handling entirely and kills the application.

Stack trace from the native crash:
```
il2cpp_field_set_value
mono_class_has_parent (×25 — walking corrupted type chain)
il2cpp_class_get_parent
il2cpp_class_get_static_field_data
```

## Root Cause

Two issues in `SyncVar<T>`:

1. **`OnDespawned()`** — calls `FlushImmediately()` without checking if `parent` is still valid. If `FlushImmediately()` throws, `UnsubscribeFromTickManager()` is never called, and the dirty flags are never reset.

2. **`OnTick()`** — only checks `!isControllingSyncVar` but not `!parent`. If the SyncVar leaks into the tick loop after despawn (due to issue #1), there's no safety net to catch and unsubscribe it.

## Fix

- **`OnDespawned()`**: Add `parent` validity check before attempting the final flush. Move dirty flag resets (`_wasLastDirty`, `_isDirty`) and `UnsubscribeFromTickManager()` outside the conditional so cleanup **always runs** regardless of whether the flush succeeds or is skipped.

- **`OnTick()`**: Add `!parent` guard so that if a SyncVar somehow remains subscribed after its parent is destroyed, it automatically unsubscribes on the next tick instead of throwing every frame.

## Testing

Tested in a 4-player multiplayer session (Steam P2P, host + 3 clients). Before the fix: 9,117 "not spawned" errors per session on host, culminating in a native IL2CPP crash. After the fix: zero errors, clean despawn/scene transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network sync reliability during object despawn and tick lifecycle by tightening guards and ensuring consistent cleanup of pending state and subscriptions.
  * Reduced unnecessary transmissions by only sending updates when appropriate, while preserving timely reliable sends when control and parent conditions are met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->