### PR TITLE
fix: add defineConstraints to UTP addon asmdefs to prevent compilation without com.unity.transport

### DIFF
--- a/Assets/PurrNet/Addons/UTP/Editor/PurrNet.UTP.Editor.asmdef
+++ b/Assets/PurrNet/Addons/UTP/Editor/PurrNet.UTP.Editor.asmdef
@@ -14,7 +14,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UTP_LOBBYRELAY"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.transport",

--- a/Assets/PurrNet/Addons/UTP/Editor/PurrNet.UTP.Editor.asmdef
+++ b/Assets/PurrNet/Addons/UTP/Editor/PurrNet.UTP.Editor.asmdef
@@ -15,13 +15,19 @@
     "precompiledReferences": [],
     "autoReferenced": false,
     "defineConstraints": [
-        "UTP_LOBBYRELAY"
+        "UTP_LOBBYRELAY",
+        "UTP_SERVICES"
     ],
     "versionDefines": [
         {
             "name": "com.unity.transport",
             "expression": "",
             "define": "UTP_LOBBYRELAY"
+        },
+        {
+            "name": "com.unity.services.multiplayer",
+            "expression": "",
+            "define": "UTP_SERVICES"
         }
     ],
     "noEngineReferences": false

--- a/Assets/PurrNet/Addons/UTP/Runtime/PurrNet.UTP.Runtime.asmdef
+++ b/Assets/PurrNet/Addons/UTP/Runtime/PurrNet.UTP.Runtime.asmdef
@@ -13,7 +13,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UTP_LOBBYRELAY"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.transport",

--- a/Assets/PurrNet/Addons/UTP/Runtime/PurrNet.UTP.Runtime.asmdef
+++ b/Assets/PurrNet/Addons/UTP/Runtime/PurrNet.UTP.Runtime.asmdef
@@ -14,7 +14,8 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [
-        "UTP_LOBBYRELAY"
+        "UTP_LOBBYRELAY",
+        "UTP_SERVICES"
     ],
     "versionDefines": [
         {

--- a/Assets/PurrNet/Addons/UTP/Runtime/PurrNet.UTP.Runtime.asmdef
+++ b/Assets/PurrNet/Addons/UTP/Runtime/PurrNet.UTP.Runtime.asmdef
@@ -26,11 +26,6 @@
         {
             "name": "com.unity.services.multiplayer",
             "expression": "",
-            "define": "UTP_LOBBYRELAY"
-        },
-        {
-            "name": "com.unity.services.multiplayer",
-            "expression": "",
             "define": "UTP_SERVICES"
         }
     ],


### PR DESCRIPTION
## Summary

- **Problem:** The UTP addon assemblies (`PurrNet.UTP.Runtime` and `PurrNet.UTP.Editor`) have `defineConstraints: []`, so they compile unconditionally. Projects with `com.unity.transport` installed (but NOT `com.unity.services.multiplayer`) hit `CS0246: The type or namespace name 'Allocation' could not be found` because the code references `Unity.Services.Relay.Models.Allocation` which only exists in `com.unity.services.multiplayer`.

- **Why `UTP_LOBBYRELAY` alone is insufficient:** The `versionDefines` set `UTP_LOBBYRELAY` when *either* `com.unity.transport` or `com.unity.services.multiplayer` is present. Since `com.unity.transport` alone triggers the define, a `defineConstraints: ["UTP_LOBBYRELAY"]` still compiles the assembly without the relay/services types available.

- **Fix:** Both asmdefs now require **two** constraints: `UTP_LOBBYRELAY` AND `UTP_SERVICES`. Multiple entries in `defineConstraints` use AND logic, so the assembly only compiles when both packages are installed — which is the only scenario where all referenced types (`Allocation`, `RelayServerData`, `RelayService`, etc.) actually exist. Also adds the missing `UTP_SERVICES` versionDefine to the Editor asmdef.

- **Zero-impact** for projects that have both `com.unity.transport` and `com.unity.services.multiplayer` installed — both defines will be set, constraints satisfied, assemblies compile as before.

## Test plan

- [ ] Project with `com.unity.transport` but WITHOUT `com.unity.services.multiplayer` → compiles cleanly (no CS0246 errors from UTP addon)
- [ ] Project with both `com.unity.transport` AND `com.unity.services.multiplayer` → UTP addon compiles and works correctly
- [ ] Project with neither package → compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated UTP addon configuration to enable Lobby/Relay and Unity Multiplayer Services conditional support, ensuring service-related compilation paths and multiplayer features are available where supported and improving compatibility with relevant Unity packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->