### PR TITLE
Disable IEquatable codegen for classes

### DIFF
--- a/Assets/PurrNet/Codegen/GenerateIEquatableInterage.cs
+++ b/Assets/PurrNet/Codegen/GenerateIEquatableInterage.cs
@@ -70,7 +70,7 @@ namespace PurrNet.Codegen
         public static void HandleType(TypeDefinition type)
         {
             if (type == null) return;
-            if (!(type.IsValueType || type.IsClass)) return;
+            if (!type.IsValueType) return;
             if (type.IsInterface) return;
             if (type.IsEnum) return;
             if (type.Module?.Assembly == null) return;


### PR DESCRIPTION
Because many third-party libraries rely on IEqualityComparer, auto-generating IEquatable on reference types can silently alter behavior across package boundaries and cause hard to diagnose regressions.

For example this causes R3 reactive property assignments to be suppressed when attempting to set it's value to a class that shares a base class with the current value, because classes of different types can evaluate as equal if their common variables are the same.

This PR removes the class type exclusion from the existing !IsValueType gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Limited IEquatable code generation to value types only; classes will no longer have IEquatable generated automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->