### PR TITLE
Evaluate visibility for dirty players

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.Rules.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.Rules.cs
@@ -12,6 +12,8 @@ namespace PurrNet
 
         private readonly PurrHashSet<PlayerID> _whitelist = new PurrHashSet<PlayerID>();
 
+        private readonly PurrHashSet<PlayerID> _whiteBlackDirtyPlayers = new PurrHashSet<PlayerID>();
+
         private readonly PurrHashSet<PlayerID> _blacklist = new PurrHashSet<PlayerID>();
 
         /// <summary>
@@ -39,19 +41,21 @@ namespace PurrNet
 
             if (_whitelist.Add(player))
             {
-                SetVisibilityDirty();
+                SetVisibilityDirty(player);
                 return true;
             }
             return false;
         }
 
-        private void SetVisibilityDirty()
+        private void SetVisibilityDirty(PlayerID player)
         {
             if (!_whiteBlackDirty)
             {
                 RegisterTickEvent(true);
                 _whiteBlackDirty = true;
             }
+
+            _whiteBlackDirtyPlayers.Add(player);
         }
 
         public bool BlacklistPlayer(PlayerID player)
@@ -65,7 +69,7 @@ namespace PurrNet
 
             if (_blacklist.Add(player))
             {
-                SetVisibilityDirty();
+                SetVisibilityDirty(player);
                 return true;
             }
             return false;
@@ -82,7 +86,7 @@ namespace PurrNet
 
             if (_whitelist.Remove(player))
             {
-                SetVisibilityDirty();
+                SetVisibilityDirty(player);
                 return true;
             }
             return false;
@@ -99,7 +103,7 @@ namespace PurrNet
 
             if (_blacklist.Remove(player))
             {
-                SetVisibilityDirty();
+                SetVisibilityDirty(player);
                 return true;
             }
             return false;

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -877,6 +877,7 @@ namespace PurrNet
             isManualSpawn = false;
             _whitelist.Clear();
             _blacklist.Clear();
+            _whiteBlackDirtyPlayers.Clear();
         }
 
         private void OnChildDespawned(NetworkIdentity networkIdentity)

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -603,8 +603,11 @@ namespace PurrNet
         {
             if (_whiteBlackDirty)
             {
+                foreach (var player in _whiteBlackDirtyPlayers)
+                    EvaluateVisibility(player);
+
+                _whiteBlackDirtyPlayers.Clear();
                 _whiteBlackDirty = false;
-                EvaluateVisibility();
                 UnregisterTickEvent(true);
             }
         }


### PR DESCRIPTION
Track which players had whitelist/blacklist changes and only re-evaluate visibility for those players. Added _whiteBlackDirtyPlayers set, changed SetVisibilityDirty to accept a PlayerID and add it to the set, updated whitelist/blacklist add/remove calls to mark the specific player, and modified the tick handler to call EvaluateVisibility(player) for each dirty player and then clear the set. This reduces work by avoiding a full visibility recomputation when only specific players are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Visibility updates are now tracked per player, fixing cases where changes were applied too broadly and improving sync accuracy.
* **Performance**
  * Reduced redundant global reevaluations by applying visibility recalculations only to affected players, decreasing unnecessary work and improving update responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->