### PR TITLE
Add GetState to StateMachines

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkStateMachine/StateMachine.cs
@@ -174,6 +174,19 @@ namespace PurrNet.StateMachine
         }
 
         /// <summary>
+        /// Returns the first state of type T in the states list, or null if not found
+        /// </summary>
+        public T GetState<T>() where T : StateNode
+        {
+            for (int i = 0; i < _syncedStates.Count; i++)
+            {
+                if (_syncedStates[i] is T match)
+                    return match;
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Checks whether the given type T is the state we are currently in
         /// </summary>
         public bool IsCurrentState<T>() where T : StateNode


### PR DESCRIPTION
I found myself needing this for my own project and thought I wanted to share this tiny, but helpful function.

Usage:
```cs
var gameEndState = machine.GetState<CustomStateNode>();
if (gameEndState != null)
    machine.SetState(gameEndState);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new method to retrieve state instances by type in StateMachine component, enabling more flexible state access and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->