### PR TITLE
Propagate worldPositionStays in parent changes

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/ChangeParentPacket.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/ChangeParentPacket.cs
@@ -9,10 +9,11 @@ namespace PurrNet.Modules
         public NetworkID childId;
         public NetworkID? newParentId;
         public int[] path;
+        public bool worldPositionStays;
 
         public override string ToString()
         {
-            return $"ChangeParentPacket: {{ sceneId: {sceneId}, childId: {childId}, newParentId: {newParentId} }}";
+            return $"ChangeParentPacket: {{ sceneId: {sceneId}, childId: {childId}, newParentId: {newParentId}, worldPositionStays: {worldPositionStays} }}";
         }
     }
 }

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -460,7 +460,7 @@ namespace PurrNet.Modules
                 return;
             }
 
-            ApplyParentChange(identity, parent, data.path, true);
+            ApplyParentChange(identity, parent, data.path, true, data.worldPositionStays);
 
             if (_asServer)
             {
@@ -490,7 +490,7 @@ namespace PurrNet.Modules
             return null;
         }
 
-        void ApplyParentChange(NetworkIdentity identity, NetworkIdentity parent, int[] path, bool refreshVisibility)
+        void ApplyParentChange(NetworkIdentity identity, NetworkIdentity parent, int[] path, bool refreshVisibility, bool worldPositionStays = true)
         {
             var idTrs = identity.transform;
             var oldParent = identity.parent;
@@ -513,9 +513,9 @@ namespace PurrNet.Modules
             if (nt) nt.StartIgnoringParentChanges();
 
             if (parent)
-                HierarchyPool.WalkThePath(parent.transform, idTrs, path, true);
+                HierarchyPool.WalkThePath(parent.transform, idTrs, path, worldPositionStays);
             else
-                idTrs.SetParent(null, true);
+                idTrs.SetParent(null, worldPositionStays);
 
             if (nt) nt.StopIgnoringParentChanges();
 
@@ -537,7 +537,7 @@ namespace PurrNet.Modules
             }
         }
 
-        public void OnParentChanged(NetworkIdentity identity, Transform parent)
+        public void OnParentChanged(NetworkIdentity identity, Transform parent, bool worldPositionStays = true)
         {
             if (!_asServer)
             {
@@ -592,7 +592,8 @@ namespace PurrNet.Modules
                     sceneId = _sceneId,
                     childId = identity.id.Value,
                     newParentId = closestNid?.id,
-                    path = identity.invertedPathToNearestParent
+                    path = identity.invertedPathToNearestParent,
+                    worldPositionStays = worldPositionStays
                 };
 
                 if (_asServer)


### PR DESCRIPTION
Add a worldPositionStays flag to ChangeParentPacket and propagate it through the parent-change flow. ApplyParentChange and OnParentChanged now accept the flag (defaulting to true for compatibility) and forward it to HierarchyPool.WalkThePath and Transform.SetParent. Update packet ToString and the packet construction so clients/servers can control whether world position is preserved when reparenting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control over world position behavior during hierarchy parent changes.
  * Expanded parent-change operations with optional parameter support while maintaining backward compatibility through sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->