### PR TITLE
Add invert logic for owner-active state toggling

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
@@ -8,6 +8,8 @@ namespace PurrNet
     [Contributor("RoxDevvv", "https://github.com/RoxDevvv")]
     public sealed class NetworkOwnershipToggle : NetworkIdentity
     {
+        [Tooltip("Invert owner logic so owner-active targets become non-owner-active, and vice versa.")]
+        [SerializeField] private bool _invert;
         [Tooltip("Components to toggle from the owner's perspective")]
         [SerializeField] private OwnershipComponentToggle[] _components;
         [Tooltip("GameObjects to toggle from the owner's perspective")]
@@ -97,13 +99,14 @@ namespace PurrNet
         public void Setup(bool asOwner)
         {
             _lastIsController = asOwner;
+            bool ownerState = _invert ? !asOwner : asOwner;
 
             for (var i = 0; i < _components.Length; i++)
             {
                 var target = _components[i].target;
                 if (!target) continue;
 
-                bool targetState = _components[i].activeAsOwner == asOwner;
+                bool targetState = _components[i].activeAsOwner == ownerState;
                 SetComponentState(target, targetState);
             }
 
@@ -112,7 +115,7 @@ namespace PurrNet
                 var target = _gameObjects[i].target;
                 if (!target) continue;
 
-                bool targetState = _gameObjects[i].activeAsOwner == asOwner;
+                bool targetState = _gameObjects[i].activeAsOwner == ownerState;
                 target.SetActive(targetState);
             }
         }


### PR DESCRIPTION
Implemented a way to invert the toggling so non owners will have objects/components enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an invert toggle option to the network ownership component, enabling inverted activation logic for owned and non-owned objects. This provides greater flexibility in controlling which entities activate based on network ownership state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->