### PR TITLE
Modify Destroy method for edit mode handling

### DIFF
--- a/Assets/PurrNet/Runtime/UnityProxy/UnityProxy.cs
+++ b/Assets/PurrNet/Runtime/UnityProxy/UnityProxy.cs
@@ -368,10 +368,23 @@ namespace PurrNet
             => Object.Instantiate(original, parent, worldPositionStays);
 
         [UsedByIL]
+
+        // Error: Destroy may not be called from edit mode! Use DestroyImmediate instead. Destroying an object in edit mode destroys it permanently.
         public static void Destroy(Object obj)
         {
-            if (OnDestroy(obj))
-                Object.Destroy(obj);
+            if (!OnDestroy(obj))
+                return;
+
+            if (!Application.isPlaying)
+            {
+#if UNITY_EDITOR
+                if (obj)
+                    Object.DestroyImmediate(obj);
+#endif
+                return;
+            }
+
+            Object.Destroy(obj);
         }
 
         public static void DestroyDirectly(Object obj)


### PR DESCRIPTION
Problem

UnityProxy.Destroy(Object obj, float t) schedules destruction via Task.Delay / UniTask.WaitForSeconds. When the delay finishes after the editor exits play mode (or during shutdown), the follow-up call uses Object.Destroy, which throws in the editor: “Destroy may not be called from edit mode! Use DestroyImmediate instead.”
The stack trace commonly shows UnityProxy/<Destroy>d__33:MoveNext and UnitySynchronizationContext:ExecuteTasks.

Solution
In UnityProxy.Destroy(Object obj), if Application.isPlaying is false, destroy with Object.DestroyImmediate in the editor instead of Object.Destroy.
Keep existing OnDestroy / despawn behavior unchanged for the play-mode path.
Optional: null-check after the async wait before calling Destroy(obj).

Testing
Enter play mode, trigger any PurrNet path that uses delayed destroy (or reproduce with a minimal delayed UnityProxy.Destroy call).
Stop play mode while a delayed destroy is pending.
Confirm no editor error in the console.
Smoke test: normal despawn/destroy while play mode is active still works.

Notes
This is primarily an editor / play-mode transition fix; runtime builds are unaffected for the normal Application.isPlaying path.
If the project prefers avoiding DestroyImmediate outside the editor, gate the fallback with #if UNITY_EDITOR (as in the patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object destruction handling with enhanced validation logic.
  * Refined editor and runtime cleanup behavior to ensure appropriate handling in both environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->