### PR TITLE
Fix LiteNetLib compilation error on Unity 6000.4

### DIFF
--- a/Assets/PurrNet/Externals/LiteNetLib/LiteNetLib.asmdef
+++ b/Assets/PurrNet/Externals/LiteNetLib/LiteNetLib.asmdef
@@ -4,8 +4,10 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+      "System.Runtime.CompilerServices.Unsafe.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],


### PR DESCRIPTION
Fix compilation issue on Unity 6000.4. Encountered after updating from PurrNet version 120.0-beta.29 to latest dev.

```
Library\PackageCache\dev.purrnet.purrnet@261bf2319001\Externals\LiteNetLib\Utils\FastBitConverter.cs(14,7): error CS0103: The name 'Unsafe' does not exist in the current context
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated networking library assembly configuration to improve dependency resolution and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->