### PR TITLE
fix: process ManualAddObserver events immediately for SyncVar parity

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -1903,7 +1903,18 @@ namespace PurrNet.Modules
             {
                 onObserverAdded?.Invoke(player, identity);
                 identity.TriggerOnPreObserverAdded(player, true);
-                _triggerLateObserverAdded.Add(new PlayerNid { player = player, nid = identity, isSpawner = true });
+                
+                // Process observer events immediately instead of deferring to PreNetworkMessages.
+                // This ensures SyncVar.OnObserverAdded → SendLatestState queues state data
+                // BEFORE the calling ServerRpc response, so predicted spawn clients receive
+                // SyncVar values before ManualFinalizeSpawn fires OnSpawned.
+                identity.TriggerOnObserverAdded(player, true);
+                onLateObserverAdded?.Invoke(player, identity);
+
+                // Fire onSentSpawnPacket so RPCModule replays buffered RPCs
+                // (e.g., ObserversRpc with bufferLast: true) for this observer.
+                if (identity.id.HasValue)
+                    onSentSpawnPacket?.Invoke(player, _sceneId, identity.id.Value);
             }
         }
 


### PR DESCRIPTION
Fix predicted spawn SyncVar parity
Predicted spawns via PredictedIdentitySpawner had empty SyncVars at OnSpawned time because ManualAddObserver deferred observer events to the next PreNetworkMessages cycle. The RPC response arrived before the SyncVar state, so the client finalized with default values.

Changed ManualAddObserver to process observer events immediately and fire onSentSpawnPacket, so SyncVar state and buffered RPC replay are queued before the ServerRpc response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new observer management events and APIs for enhanced control, including HierarchyV2.onPreSpawn callback

* **Bug Fixes**
  * Improved bounds validation and safety checks for data reading operations

* **Breaking Changes**
  * Authentication-related method names updated for consistency
  * Observer callback execution behavior changed from deferred to immediate processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->