### PR TITLE
Add buildIndex back to PendingSceneOperation

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Scenes/ScenesModule.cs
@@ -11,6 +11,7 @@ namespace PurrNet.Modules
 {
     public struct PendingSceneOperation
     {
+        public int buildIndex;
         public uint scenePathHash;
         public SceneID idToAssign;
         public PurrSceneSettings settings;
@@ -513,6 +514,7 @@ namespace PurrNet.Modules
 
                         _pendingOperations.Add(new PendingSceneOperation
                         {
+                            buildIndex = localBuildIndex,
                             scenePathHash = loadAction.scenePathHash,
                             settings = loadAction.parameters,
                             idToAssign = loadAction.sceneID,
@@ -847,6 +849,7 @@ namespace PurrNet.Modules
             var op = SceneManager.LoadSceneAsync(sceneIndex, parameters);
             var operation = new PendingSceneOperation
             {
+                buildIndex = sceneIndex,
                 scenePathHash = scenePathHash,
                 settings = settings,
                 idToAssign = idToAssign,


### PR DESCRIPTION
Adds back the build index to the PendinSceneOperation struct (which makes checking whether a specific is currently loading much more convenient)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scene loading to properly track and record scene build indices during load operations, ensuring correct scene state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->