### PR TITLE
NetworkManager tick rate accessor

### DIFF
--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -121,6 +121,30 @@ namespace PurrNet
         }
 
         /// <summary>
+        /// Number of target ticks per second.
+        /// </summary>
+        public int tickRate
+        {
+            get => _tickRate;
+            set
+            {
+                if (value < 1)
+                {
+                    PurrLogger.LogError("Failed to update tick rate since it must be greater than zero.");
+                    return;
+                }
+
+                if (_serverTickManager != null || _clientTickManager != null)
+                {
+                    PurrLogger.LogError("Failed to update tick rate since a tick manager is already running.");
+                    return;
+                }
+
+                _tickRate = value;
+            }
+        }
+
+        /// <summary>
         /// The start flags of the server.
         /// This is used to determine when the server should automatically start.
         /// </summary>


### PR DESCRIPTION
Allows programatically setting NetworkManager tick rate. Fails if the value is invalid (less than one) or if a tick manager has already been created. See [Discord discussion](https://discord.com/channels/1288872904272121957/1494049494155661382).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tick rate is now configurable as a public property with built-in safeguards. Invalid values are rejected, and updates are prevented while the system is actively running to maintain stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->