### PR TITLE
fix: DisposableList ToString null exception

### DIFF
--- a/Assets/PurrNet/Runtime/Pooling/DisposableList.cs
+++ b/Assets/PurrNet/Runtime/Pooling/DisposableList.cs
@@ -35,6 +35,11 @@ namespace PurrNet.Pooling
 
         public override string ToString()
         {
+            if (list == null)
+            {
+                return "null";
+            }
+
             return string.Concat("[", string.Join(", ", list), "]");
         }
 


### PR DESCRIPTION
On dev branch of PurrDiction, if you have PredictedPlayers selected on inspector while in game, the logs fill with "Value cannot be null" error.

<img width="2533" height="830" alt="image" src="https://github.com/user-attachments/assets/6f582074-a6ef-4ac3-a127-b345eac8d6d4" />


This is caused by PredictedPlayersInput DisposableList internal list being null.

<img width="757" height="567" alt="image" src="https://github.com/user-attachments/assets/f5e0a334-63bf-4ae6-802b-b73e50c0b413" />

Fix is to check is list is null in the DisposableList toString method.

<img width="650" height="328" alt="image" src="https://github.com/user-attachments/assets/107a2509-1554-4a78-a76f-4f0826b0e975" />


<img width="870" height="335" alt="image" src="https://github.com/user-attachments/assets/264f1250-fc08-4ada-b106-8da8ae985c76" />

Took a quick glance in the repos other similar places but couldn't find any which caught my eye.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when converting certain internal objects to strings under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->