### PR TITLE
Removed unnecessary disabling of animator in NetworkAnimator

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkAnimator/NetworkAnimator.cs
@@ -89,18 +89,6 @@ namespace PurrNet
             }
         }
 
-        void OnEnable()
-        {
-            if (_animator && !_animator.enabled)
-                _animator.enabled = true;
-        }
-
-        void OnDisable()
-        {
-            if (_animator && _animator.enabled)
-                _animator.enabled = false;
-        }
-
         private void Reset()
         {
             _animator = GetComponent<Animator>();


### PR DESCRIPTION
The NetworkAnimator currently disables it's Unity Animator component when it is disabled, and re-enables when enabled. This functionality isn't necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * NetworkAnimator component no longer automatically controls the animator's enabled state, allowing other systems to manage animator behavior independently without conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->