### PR TITLE
Fix parameter passing in GiveOwnership

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -1085,7 +1085,7 @@ namespace PurrNet
         {
             if (!player.HasValue)
             {
-                RemoveOwnership();
+                RemoveOwnership(propagateToChildren);
                 return;
             }
 


### PR DESCRIPTION
### Problem

When method `GiveOwnership(null, propagateToChildren: false)` is called, parameter `propagateToChildren` is ignored.

This PR will fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network ownership removal behavior to properly respect propagation settings for child entities. When removing ownership from a networked entity, the system now correctly forwards the relevant propagation parameters to ensure that child entities are affected according to the specified propagation settings, improving consistency in network state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->