### PR TITLE
fix: Cache LateLateUpdate delegate for event subscription avoid GC when enabling and disabling it

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkBehaviour/NetworkTransform.cs
@@ -135,8 +135,11 @@ namespace PurrNet
         public Quaternion rotation { get; private set; }
         public Vector3 localScale { get; private set; }
 
+        private Action _lateLateUpdateCallback;
+
         private void Awake()
         {
+            _lateLateUpdateCallback = LateLateUpdate;
             _trs = transform;
 #if UNITY_PHYSICS_3D
             _rb = GetComponent<Rigidbody>();
@@ -151,7 +154,7 @@ namespace PurrNet
 
         private void OnEnable()
         {
-            UnityLatestUpdate.onLatestUpdate += LateLateUpdate;
+            UnityLatestUpdate.onLatestUpdate += _lateLateUpdateCallback;
 
             if (_trs == null)
                 return;
@@ -171,7 +174,7 @@ namespace PurrNet
 
         private void OnDisable()
         {
-            UnityLatestUpdate.onLatestUpdate -= LateLateUpdate;
+            UnityLatestUpdate.onLatestUpdate -= _lateLateUpdateCallback;
         }
 
         protected override void OnEarlySpawn()


### PR DESCRIPTION
Introduce a private Action (_lateLateUpdateCallback) assigned to LateLateUpdate in Awake and use it for subscribing/unsubscribing to UnityLatestUpdate.onLatestUpdate. This ensures the same delegate instance is used for add/remove, avoiding potential mismatched delegate references and extra allocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized network transform update callback handling for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->