### PR TITLE
QOL: Add support for Pose packing

### DIFF
--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackUnityTypes.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackUnityTypes.cs
@@ -282,10 +282,41 @@ namespace PurrNet.Packing
         }
 
         [UsedByIL]
+        private static bool DeltaWritePose(BitPacker packer, Pose old, Pose newValue)
+        {
+            var delta = new DeltaWritingScope(packer);
+
+            delta.Write(old.position, newValue.position);
+            delta.Write(old.rotation, newValue.rotation);
+
+            return delta.Complete();
+        }
+
+        [UsedByIL]
         public static void Read(this BitPacker packer, ref Pose value)
         {
             packer.Read(ref value.position);
             packer.Read(ref value.rotation);
+        }
+
+        [UsedByIL]
+        private static void DeltaReadPose(BitPacker packer, Pose old, ref Pose value)
+        {
+            if (!packer.ReadBit())
+            {
+                value.position = old.position;
+                value.rotation = old.rotation;
+                return;
+            }
+
+            var position = old.position;
+            var rotation = old.rotation;
+
+            DeltaPacker<Vector3>.Read(packer, old.position, ref position);
+            DeltaPacker<Quaternion>.Read(packer, old.rotation, ref rotation);
+
+            value.position = position;
+            value.rotation = rotation;
         }
         #endif
 

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackUnityTypes.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackUnityTypes.cs
@@ -273,6 +273,22 @@ namespace PurrNet.Packing
             value.w = *(float*)&wbits;
         }
 
+        #if UNITY_2021_1_OR_NEWER
+        [UsedByIL]
+        public static void Write(this BitPacker packer, Pose value)
+        {
+            packer.Write(value.position);
+            packer.Write(value.rotation);
+        }
+
+        [UsedByIL]
+        public static void Read(this BitPacker packer, ref Pose value)
+        {
+            packer.Read(ref value.position);
+            packer.Read(ref value.rotation);
+        }
+        #endif
+
         [UsedByIL]
         public static void Write(this BitPacker packer, Color32 value)
         {

--- a/Assets/PurrNet/Runtime/BitPacker/Packers/PackUnityTypes.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/Packers/PackUnityTypes.cs
@@ -273,7 +273,7 @@ namespace PurrNet.Packing
             value.w = *(float*)&wbits;
         }
 
-        #if UNITY_2021_1_OR_NEWER
+        #if UNITY_2017_3_OR_NEWER
         [UsedByIL]
         public static void Write(this BitPacker packer, Pose value)
         {


### PR DESCRIPTION
### QOL

Unity includes a standard [Pose](https://docs.unity3d.com/6000.0/Documentation/ScriptReference/Pose.html) structure for passing an object's position and rotation together.

It was added a long time ago, but just to be safe, I've added a check for version ~~2021.1~~ 2017.3 and above, since I couldn't find any explicit mention of the minimum supported Unity version anywhere.

This PR adds the ability to transmit this structure over the network out of the box.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783226039&installation_id=129033668&pr_number=259&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F259&signature=12d8ddba7a18ce80344314abb7005d4bdb1e506a734bbbbdf7712a669610adda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BitPacker support for Unity `Pose`, including serialization (position + rotation) and matching deserialization for efficient network synchronization.
  * Available on Unity 2017.3 and newer.
  * Helps multiplayer applications transmit pose data reliably and with reduced payload size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->