### PR TITLE
Fix SyncVar value on spawn for pooled objects

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -80,6 +80,7 @@ namespace PurrNet
             _wasLastDirty = false;
             _id = 0;
             _ignoreServerUpdates = false;
+            _value = _initialValue;
         }
 
         public override void OnOwnerDisconnected(PlayerID ownerId)
@@ -248,9 +249,11 @@ namespace PurrNet
 
         private ulong _id;
         private bool _wasLastDirty;
+        private readonly T _initialValue;
 
         public SyncVar(T initialValue = default, float sendIntervalInSeconds = 0f, bool ownerAuth = false)
         {
+            _initialValue = initialValue;
             _value = initialValue;
             _sendIntervalInSeconds = sendIntervalInSeconds;
             _ownerAuth = ownerAuth;


### PR DESCRIPTION
### Problem

When objects are used via a pool and contain any SyncVars, after a SyncVar is modified and the object is returned to the pool, all values remain unchanged. As a result, when the object is spawned again from the pool, the initial values will differ from the actual InitialValue.

Attempting to reset or synchronize each SyncVar manually when spawning the object seems like a very inconvenient and unreliable method.

This PR proposes explicitly setting the initialValue when returning the object to the pool, which seems like the most expected behavior.

P.S. Unfortunately, I can't test whether this mechanism works, since method `SyncVar<T>.OnPoolReset` isn't being called at all right now when the parent object is returned to the pool.

I mentioned this earlier on [Discord](https://discord.com/channels/1288872904272121957/1496893903897493544/1498641646164906174).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783230392&installation_id=129033668&pr_number=260&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F260&signature=88888b6fbff438587a3f9c644e162d4c9b82b98eec7126d7321304180740bd78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed networked synchronized values not properly resetting to their initial state when pooled objects are reused, ensuring correct state initialization across the object lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->