### PR TITLE
Lod test

### DIFF
--- a/Assets/PlayModeTests/Bootstrap.unity
+++ b/Assets/PlayModeTests/Bootstrap.unity
@@ -1651,6 +1651,8 @@ GameObject:
   - component: {fileID: 1680343642}
   - component: {fileID: 1680343643}
   - component: {fileID: 1680343644}
+  - component: {fileID: 1680343645}
+  - component: {fileID: 1680343646}
   m_Layer: 0
   m_Name: Lifetimes
   m_TagString: Untagged
@@ -2028,6 +2030,40 @@ MonoBehaviour:
   _syncTimeoutSeconds: 30
   _despawnTimeoutSeconds: 30
   _barrierTimeoutSeconds: 60
+--- !u!114 &1680343645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1680343622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb337da9b58f453f81196b704993cffb, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: PurrNet.PlayModeTests::NetworkLODTierScenario
+  _spawnTimeoutSeconds: 20
+  _tierTimeoutSeconds: 20
+  _cadenceTimeoutSeconds: 30
+  _despawnTimeoutSeconds: 20
+  _barrierTimeoutSeconds: 120
+  _settleSeconds: 0.75
+--- !u!114 &1680343646
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1680343622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 679af572dd3e4b3fb0428c6112c2ca51, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: PurrNet.PlayModeTests::NetworkLODCullScenario
+  _spawnTimeoutSeconds: 20
+  _visibilityTimeoutSeconds: 30
+  _despawnTimeoutSeconds: 20
+  _barrierTimeoutSeconds: 120
 --- !u!1 &1869161003
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/PlayModeTests/Scripts/LODTests.meta
+++ b/Assets/PlayModeTests/Scripts/LODTests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2417fadfa0e429a8e60a6841df2ffcd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullScenario.cs
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullScenario.cs
@@ -1,0 +1,179 @@
+using System;
+using Cysharp.Threading.Tasks;
+using PurrNet;
+using PurrNet.Modules;
+using UnityEngine;
+
+/// <summary>
+/// LOD culling contract: with cullBeyondLastTier + a LODVisibilityRule override, moving beyond the
+/// last band removes every observer (clients despawn) and moving back re-adds them (clients respawn).
+/// </summary>
+public class NetworkLODCullScenario : Scenario
+{
+    [SerializeField] private float _spawnTimeoutSeconds = 20f;
+    [SerializeField] private float _visibilityTimeoutSeconds = 30f;
+    [SerializeField] private float _despawnTimeoutSeconds = 20f;
+    [SerializeField] private float _barrierTimeoutSeconds = 120f;
+
+    private const int BarrierBase = 5700;
+
+    private static readonly Vector3 BasePos = new Vector3(-1000f, 0f, 0f);
+
+    private NetworkLODCullTarget _prefab;
+
+    void CreatePrefab()
+    {
+        var go = new GameObject(nameof(NetworkLODCullTarget));
+        _prefab = go.AddComponent<NetworkLODCullTarget>();
+        var lod = go.AddComponent<NetworkLOD>();
+
+        var profile = ScriptableObject.CreateInstance<NetworkLODProfile>();
+        profile.Configure(new[]
+        {
+            new NetworkLODTier { maxDistance = 30f, hysteresis = 5f, sendIntervalTicks = 1 }
+        }, true);
+        lod.profile = profile;
+
+        go.SetActive(false);
+        NetworkLODCullTarget.ResetAll();
+    }
+
+    public override void Setup(ScenarioContext ctx, NetworkManager manager)
+    {
+        CreatePrefab();
+
+        var ruleSet = ScriptableObject.CreateInstance<NetworkVisibilityRuleSet>();
+        ruleSet.Setup(manager);
+        ruleSet.AddRule(manager, ScriptableObject.CreateInstance<LODVisibilityRule>());
+
+        var identities = _prefab.GetComponents<NetworkIdentity>();
+        for (var i = 0; i < identities.Length; i++)
+            identities[i].SetVisibilityRules(ruleSet);
+
+        manager.prefabProvider.AddRuntimePrefab(_prefab.name, _prefab.gameObject);
+    }
+
+    public override async UniTask<ScenarioResult> RunScenario(ScenarioContext ctx)
+    {
+        NetworkLODCullTarget instance = null;
+        GameObject anchorGo = null;
+        NetworkLODFactory lodFactory = null;
+
+        if (ctx.isServer)
+        {
+            lodFactory = ctx.networkManager.lodModule;
+            if (lodFactory == null)
+                return ScenarioResult.Fail("NetworkLODFactory module not found");
+
+            anchorGo = new GameObject("NetworkLODCullScenarioAnchor");
+            anchorGo.transform.position = BasePos;
+
+            var players = ctx.networkManager.players;
+            for (var i = 0; i < players.Count; i++)
+            {
+                if (!players[i].isServer)
+                    lodFactory.RegisterAnchor(players[i], anchorGo.transform);
+            }
+
+            HierarchyV2.SupressAutoOwner();
+            try { instance = Instantiate(_prefab, BasePos + new Vector3(10f, 0f, 0f), Quaternion.identity); }
+            finally { HierarchyV2.ResumeAutoOwner(); }
+        }
+
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => NetworkLODCullTarget.localInstance != null && NetworkLODCullTarget.aliveCount == 1,
+                _spawnTimeoutSeconds, ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            return ScenarioResult.Fail(
+                $"initial spawn never observed: alive={NetworkLODCullTarget.aliveCount}");
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 1, _barrierTimeoutSeconds);
+
+        if (ctx.isServer)
+            instance.transform.position = BasePos + new Vector3(100f, 0f, 0f);
+
+        try
+        {
+            if (ctx.isServer)
+            {
+                await UniTaskUtils.WaitWithTimeout(
+                    () => instance.observers.Count == 0,
+                    _visibilityTimeoutSeconds, ctx.cancellationToken);
+            }
+            else
+            {
+                await UniTaskUtils.WaitWithTimeout(
+                    () => NetworkLODCullTarget.localInstance == null && NetworkLODCullTarget.aliveCount == 0,
+                    _visibilityTimeoutSeconds, ctx.cancellationToken);
+            }
+        }
+        catch (TimeoutException)
+        {
+            return ScenarioResult.Fail(ctx.isServer
+                ? $"cull: observers never emptied: {instance.observers.Count}"
+                : $"cull: client never saw the despawn: alive={NetworkLODCullTarget.aliveCount}");
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 2, _barrierTimeoutSeconds);
+
+        if (ctx.isServer)
+            instance.transform.position = BasePos + new Vector3(10f, 0f, 0f);
+
+        try
+        {
+            if (ctx.isServer)
+            {
+                await UniTaskUtils.WaitWithTimeout(
+                    () => instance.observers.Count == ctx.expectedConnections,
+                    _visibilityTimeoutSeconds, ctx.cancellationToken);
+            }
+            else
+            {
+                await UniTaskUtils.WaitWithTimeout(
+                    () => NetworkLODCullTarget.localInstance != null && NetworkLODCullTarget.aliveCount == 1,
+                    _visibilityTimeoutSeconds, ctx.cancellationToken);
+            }
+        }
+        catch (TimeoutException)
+        {
+            return ScenarioResult.Fail(ctx.isServer
+                ? $"un-cull: observers={instance.observers.Count}/{ctx.expectedConnections}"
+                : $"un-cull: client never saw the respawn: alive={NetworkLODCullTarget.aliveCount}");
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 3, _barrierTimeoutSeconds);
+
+        if (ctx.isServer)
+        {
+            var players = ctx.networkManager.players;
+            for (var i = 0; i < players.Count; i++)
+            {
+                if (!players[i].isServer)
+                    lodFactory.UnregisterAnchor(players[i], anchorGo.transform);
+            }
+
+            Destroy(anchorGo);
+            instance.Despawn();
+        }
+
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => NetworkLODCullTarget.localInstance == null && NetworkLODCullTarget.aliveCount == 0,
+                _despawnTimeoutSeconds, ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            return ScenarioResult.Fail($"cleanup incomplete: alive={NetworkLODCullTarget.aliveCount}");
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 4, _barrierTimeoutSeconds);
+
+        return ScenarioResult.Ok("cull/un-cull cycle drove observer removal and re-add");
+    }
+}

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullScenario.cs.meta
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullScenario.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 679af572dd3e4b3fb0428c6112c2ca51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullTarget.cs
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullTarget.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using PurrNet;
+
+/// <summary>
+/// LOD-governed identity for NetworkLODCullScenario; tracks liveness per peer.
+/// </summary>
+public class NetworkLODCullTarget : NetworkIdentity
+{
+    public static NetworkLODCullTarget localInstance;
+
+    static readonly HashSet<NetworkID> _alive = new HashSet<NetworkID>();
+
+    public static int aliveCount => _alive.Count;
+
+    NetworkID? _trackedId;
+
+    public static void ResetAll()
+    {
+        localInstance = null;
+        _alive.Clear();
+    }
+
+    protected override void OnEarlySpawn() => gameObject.SetActive(true);
+
+    protected override void OnSpawned()
+    {
+        localInstance = this;
+        if (id.HasValue)
+        {
+            _trackedId = id.Value;
+            _alive.Add(id.Value);
+        }
+    }
+
+    protected override void OnDespawned()
+    {
+        if (_trackedId.HasValue)
+            _alive.Remove(_trackedId.Value);
+        _trackedId = null;
+
+        if (localInstance == this)
+            localInstance = null;
+    }
+}

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullTarget.cs.meta
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODCullTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6e9c92a849d4a7eb1a5afde890d739c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODOwnedAnchor.cs
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODOwnedAnchor.cs
@@ -1,0 +1,21 @@
+using PurrNet;
+
+/// <summary>
+/// Identity given to the victim player to verify the owned-identity distance fallback.
+/// </summary>
+public class NetworkLODOwnedAnchor : NetworkIdentity
+{
+    public static NetworkLODOwnedAnchor localInstance;
+
+    public static void ResetAll() => localInstance = null;
+
+    protected override void OnEarlySpawn() => gameObject.SetActive(true);
+
+    protected override void OnSpawned() => localInstance = this;
+
+    protected override void OnDespawned()
+    {
+        if (localInstance == this)
+            localInstance = null;
+    }
+}

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODOwnedAnchor.cs.meta
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODOwnedAnchor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1c5cb30ee72a48ed91acaba1ab559d41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierScenario.cs
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierScenario.cs
@@ -1,0 +1,293 @@
+using System;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using PurrNet;
+using PurrNet.Modules;
+using UnityEngine;
+
+/// <summary>
+/// Core network LOD contract: distance bands resolve per-player tiers (owned identities as
+/// fallback, registered anchors taking precedence), hysteresis holds at band edges, tier changes
+/// fire the virtual + event, and ShouldSendToPlayer gates at exactly the tier's interval.
+/// </summary>
+public class NetworkLODTierScenario : Scenario
+{
+    [SerializeField] private float _spawnTimeoutSeconds = 20f;
+    [SerializeField] private float _tierTimeoutSeconds = 20f;
+    [SerializeField] private float _cadenceTimeoutSeconds = 30f;
+    [SerializeField] private float _despawnTimeoutSeconds = 20f;
+    [SerializeField] private float _barrierTimeoutSeconds = 120f;
+    [SerializeField] private float _settleSeconds = 0.75f;
+
+    private const int BarrierBase = 5800;
+    private const int CadenceTicks = 40;
+
+    private static readonly Vector3 BasePos = new Vector3(1000f, 0f, 0f);
+
+    private NetworkLODTierTarget _prefabTarget;
+    private NetworkLODOwnedAnchor _prefabOwned;
+
+    void CreatePrefabs()
+    {
+        var targetGo = new GameObject(nameof(NetworkLODTierTarget));
+        _prefabTarget = targetGo.AddComponent<NetworkLODTierTarget>();
+        var lod = targetGo.AddComponent<NetworkLOD>();
+
+        var profile = ScriptableObject.CreateInstance<NetworkLODProfile>();
+        profile.Configure(new[]
+        {
+            new NetworkLODTier { maxDistance = 10f, hysteresis = 5f, sendIntervalTicks = 1 },
+            new NetworkLODTier { maxDistance = 30f, hysteresis = 5f, sendIntervalTicks = 2 },
+            new NetworkLODTier { maxDistance = 100f, hysteresis = 10f, sendIntervalTicks = 4 }
+        }, false);
+        lod.profile = profile;
+
+        targetGo.SetActive(false);
+
+        var ownedGo = new GameObject(nameof(NetworkLODOwnedAnchor));
+        _prefabOwned = ownedGo.AddComponent<NetworkLODOwnedAnchor>();
+        ownedGo.SetActive(false);
+
+        NetworkLODTierTarget.ResetAll();
+        NetworkLODOwnedAnchor.ResetAll();
+    }
+
+    public override void Setup(ScenarioContext ctx, NetworkManager manager)
+    {
+        CreatePrefabs();
+        manager.prefabProvider.AddRuntimePrefab(_prefabTarget.name, _prefabTarget.gameObject);
+        manager.prefabProvider.AddRuntimePrefab(_prefabOwned.name, _prefabOwned.gameObject);
+    }
+
+    public override async UniTask<ScenarioResult> RunScenario(ScenarioContext ctx)
+    {
+        NetworkLODTierTarget instance = null;
+
+        if (ctx.isServer)
+        {
+            HierarchyV2.SupressAutoOwner();
+            try { instance = Instantiate(_prefabTarget, BasePos, Quaternion.identity); }
+            finally { HierarchyV2.ResumeAutoOwner(); }
+        }
+
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => NetworkLODTierTarget.localInstance != null,
+                _spawnTimeoutSeconds, ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            return ScenarioResult.Fail("target spawn never observed");
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 1, _barrierTimeoutSeconds);
+
+        ScenarioResult serverResult = default;
+        bool serverRan = false;
+
+        if (ctx.isServer)
+        {
+            serverResult = await RunServerPhases(ctx, instance);
+            serverRan = true;
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 2, _barrierTimeoutSeconds);
+
+        if (ctx.isServer && instance)
+            instance.Despawn();
+
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => NetworkLODTierTarget.localInstance == null && NetworkLODOwnedAnchor.localInstance == null,
+                _despawnTimeoutSeconds, ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            return ScenarioResult.Fail(
+                $"cleanup incomplete: target={NetworkLODTierTarget.localInstance != null}, " +
+                $"owned={NetworkLODOwnedAnchor.localInstance != null}");
+        }
+
+        await ScenarioBarrier.Wait(ctx, BarrierBase + 3, _barrierTimeoutSeconds);
+
+        if (serverRan && !serverResult.success)
+            return serverResult;
+
+        return ScenarioResult.Ok(ctx.isServer ? serverResult.message : "observer");
+    }
+
+    private async UniTask<ScenarioResult> RunServerPhases(ScenarioContext ctx, NetworkLODTierTarget instance)
+    {
+        var failures = new List<string>();
+        var manager = ctx.networkManager;
+        var lod = instance.GetComponent<NetworkLOD>();
+
+        var victim = PickVictim(ctx);
+        if (!victim.HasValue)
+            return ScenarioResult.Fail("no eligible non-server / non-host-local player");
+
+        var lodFactory = manager.lodModule;
+        if (lodFactory == null)
+            return ScenarioResult.Fail("NetworkLODFactory module not found");
+
+        NetworkLODOwnedAnchor ownedInstance = null;
+        GameObject anchorGo = null;
+
+        try
+        {
+            /* settle first: leftovers owned by the victim can add a pre-phase transition */
+            await UniTask.Delay(TimeSpan.FromSeconds(_settleSeconds), cancellationToken: ctx.cancellationToken);
+            int baselineVirtual = NetworkLODTierTarget.GetVirtualCount(victim.Value);
+            int baselineEvent = NetworkLODTierTarget.GetEventCount(victim.Value);
+
+            ownedInstance = Instantiate(_prefabOwned, BasePos + new Vector3(20f, 0f, 0f), Quaternion.identity);
+            ownedInstance.GiveOwnership(victim.Value);
+
+            if (!await WaitTier(ctx, lod, victim.Value, 1, failures, "owned-identity fallback"))
+                return ScenarioResult.Fail(string.Join(" | ", failures));
+
+            anchorGo = new GameObject("NetworkLODTierScenarioAnchor");
+            anchorGo.transform.position = BasePos + new Vector3(5f, 0f, 0f);
+            lodFactory.RegisterAnchor(victim.Value, anchorGo.transform);
+
+            if (!await WaitTier(ctx, lod, victim.Value, 0, failures, "anchor precedence"))
+                return ScenarioResult.Fail(string.Join(" | ", failures));
+
+            instance.transform.position = BasePos + new Vector3(0f, 0f, 50f);
+
+            if (!await WaitTier(ctx, lod, victim.Value, 2, failures, "band move"))
+                return ScenarioResult.Fail(string.Join(" | ", failures));
+
+            int virtualCount = NetworkLODTierTarget.GetVirtualCount(victim.Value) - baselineVirtual;
+            int eventCount = NetworkLODTierTarget.GetEventCount(victim.Value) - baselineEvent;
+            var lastChange = NetworkLODTierTarget.GetLastChange(victim.Value);
+
+            if (virtualCount != 3)
+                failures.Add($"expected 3 virtual tier changes for victim, got {virtualCount}");
+            if (eventCount != 3)
+                failures.Add($"expected 3 event tier changes for victim, got {eventCount}");
+            if (lastChange != (0, 2))
+                failures.Add($"last change mismatch: {lastChange?.previous}->{lastChange?.next}, expected 0->2");
+
+            /* distances below are measured from the anchor at x=5 */
+            instance.transform.position = BasePos + new Vector3(37f, 0f, 0f);
+            await UniTask.Delay(TimeSpan.FromSeconds(_settleSeconds), cancellationToken: ctx.cancellationToken);
+            if (lod.GetTier(victim.Value) != 2)
+                failures.Add($"hysteresis: dist 32 demoted early to tier {lod.GetTier(victim.Value)}, expected 2");
+
+            instance.transform.position = BasePos + new Vector3(33f, 0f, 0f);
+            if (!await WaitTier(ctx, lod, victim.Value, 1, failures, "promotion to tier 1"))
+                return ScenarioResult.Fail(string.Join(" | ", failures));
+
+            instance.transform.position = BasePos + new Vector3(38f, 0f, 0f);
+            await UniTask.Delay(TimeSpan.FromSeconds(_settleSeconds), cancellationToken: ctx.cancellationToken);
+            if (lod.GetTier(victim.Value) != 1)
+                failures.Add($"hysteresis: dist 33 flapped to tier {lod.GetTier(victim.Value)}, expected 1");
+
+            instance.transform.position = BasePos + new Vector3(45f, 0f, 0f);
+            if (!await WaitTier(ctx, lod, victim.Value, 2, failures, "demotion to tier 2"))
+                return ScenarioResult.Fail(string.Join(" | ", failures));
+
+            int sends = await CountSends(ctx, lod, victim.Value);
+            if (sends != CadenceTicks / 4)
+                failures.Add($"tier 2 cadence: {sends}/{CadenceTicks} ticks sent, expected {CadenceTicks / 4}");
+
+            instance.transform.position = BasePos + new Vector3(33f, 0f, 0f);
+            if (!await WaitTier(ctx, lod, victim.Value, 1, failures, "cadence re-promotion"))
+                return ScenarioResult.Fail(string.Join(" | ", failures));
+
+            sends = await CountSends(ctx, lod, victim.Value);
+            if (sends != CadenceTicks / 2)
+                failures.Add($"tier 1 cadence: {sends}/{CadenceTicks} ticks sent, expected {CadenceTicks / 2}");
+        }
+        finally
+        {
+            if (anchorGo)
+            {
+                lodFactory.UnregisterAnchor(victim.Value, anchorGo.transform);
+                Destroy(anchorGo);
+            }
+
+            if (ownedInstance)
+                ownedInstance.Despawn();
+        }
+
+        return failures.Count == 0
+            ? ScenarioResult.Ok($"victim={victim.Value.id.value}, tiers/hysteresis/cadence verified")
+            : ScenarioResult.Fail(string.Join(" | ", failures));
+    }
+
+    private async UniTask<bool> WaitTier(ScenarioContext ctx, NetworkLOD lod, PlayerID player, byte expected,
+        List<string> failures, string phase)
+    {
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => lod.GetTier(player) == expected,
+                _tierTimeoutSeconds, ctx.cancellationToken);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            failures.Add($"{phase}: tier stuck at {lod.GetTier(player)}, expected {expected}");
+            return false;
+        }
+    }
+
+    private async UniTask<int> CountSends(ScenarioContext ctx, NetworkLOD lod, PlayerID player)
+    {
+        int ticks = 0;
+        int sends = 0;
+        var tickManager = ctx.networkManager.tickModule;
+
+        void OnTick()
+        {
+            if (ticks >= CadenceTicks)
+                return;
+            if (lod.ShouldSendToPlayer(player))
+                sends++;
+            ticks++;
+        }
+
+        tickManager.onTick += OnTick;
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => ticks >= CadenceTicks,
+                _cadenceTimeoutSeconds, ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            sends = -1;
+        }
+        finally
+        {
+            tickManager.onTick -= OnTick;
+        }
+
+        return sends;
+    }
+
+    private static PlayerID? PickVictim(ScenarioContext ctx)
+    {
+        var manager = ctx.networkManager;
+        var hostLocal = manager.isLocalPlayerReady && ctx.role == NetworkRole.Host
+            ? manager.localPlayer
+            : (PlayerID?)null;
+
+        PlayerID? best = null;
+        var players = manager.players;
+        for (int i = 0; i < players.Count; i++)
+        {
+            var p = players[i];
+            if (p.isServer) continue;
+            if (hostLocal.HasValue && hostLocal.Value == p) continue;
+            if (!best.HasValue || p.id.value < best.Value.id.value)
+                best = p;
+        }
+
+        return best;
+    }
+}

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierScenario.cs.meta
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierScenario.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb337da9b58f453f81196b704993cffb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierTarget.cs
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierTarget.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using PurrNet;
+
+/// <summary>
+/// LOD-governed identity for NetworkLODTierScenario; records server-side tier changes per player.
+/// </summary>
+public class NetworkLODTierTarget : NetworkIdentity
+{
+    public static NetworkLODTierTarget localInstance;
+
+    static readonly Dictionary<PlayerID, int> _virtualCounts = new Dictionary<PlayerID, int>();
+    static readonly Dictionary<PlayerID, int> _eventCounts = new Dictionary<PlayerID, int>();
+    static readonly Dictionary<PlayerID, (byte previous, byte next)> _lastChange =
+        new Dictionary<PlayerID, (byte, byte)>();
+
+    public static void ResetAll()
+    {
+        localInstance = null;
+        _virtualCounts.Clear();
+        _eventCounts.Clear();
+        _lastChange.Clear();
+    }
+
+    public static int GetVirtualCount(PlayerID player) =>
+        _virtualCounts.TryGetValue(player, out var c) ? c : 0;
+
+    public static int GetEventCount(PlayerID player) =>
+        _eventCounts.TryGetValue(player, out var c) ? c : 0;
+
+    public static (byte previous, byte next)? GetLastChange(PlayerID player) =>
+        _lastChange.TryGetValue(player, out var c) ? c : ((byte, byte)?)null;
+
+    protected override void OnEarlySpawn() => gameObject.SetActive(true);
+
+    protected override void OnSpawned()
+    {
+        localInstance = this;
+        onLODTierChanged += OnTierEvent;
+    }
+
+    protected override void OnDespawned()
+    {
+        onLODTierChanged -= OnTierEvent;
+        if (localInstance == this)
+            localInstance = null;
+    }
+
+    private static void OnTierEvent(PlayerID player, byte previousTier, byte newTier)
+    {
+        _eventCounts[player] = GetEventCount(player) + 1;
+    }
+
+    protected override void OnLODTierChanged(PlayerID player, byte previousTier, byte newTier)
+    {
+        _virtualCounts[player] = GetVirtualCount(player) + 1;
+        _lastChange[player] = (previousTier, newTier);
+    }
+}

--- a/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierTarget.cs.meta
+++ b/Assets/PlayModeTests/Scripts/LODTests/NetworkLODTierTarget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa883ec43b6049fbbd5c88b4fe0779af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PlayModeTests/Scripts/LifecycleTests/LateJoinScenario.cs
+++ b/Assets/PlayModeTests/Scripts/LifecycleTests/LateJoinScenario.cs
@@ -21,7 +21,7 @@ public class LateJoinScenario : Scenario
     [SerializeField] private float _stayDisconnectedSeconds = 1.0f;
     [SerializeField] private float _barrierTimeoutSeconds = 60f;
 
-    private const int BarrierEnd = 4200;
+    private const int BarrierEnd = 4250;
 
     private LateJoinIdentity _prefab;
 

--- a/Assets/PlayModeTests/Scripts/ScenarioBarrier.cs
+++ b/Assets/PlayModeTests/Scripts/ScenarioBarrier.cs
@@ -12,7 +12,11 @@ public static class ScenarioBarrier
     // before completion — it forwards OnCompleted to the underlying state-machine source,
     // which only allows one continuation.
     private static readonly Dictionary<int, Task> _inFlight = new();
-    private static int _lastProceedBarrier = -1;
+    // Exact-match per-id proceeds (NOT a high-water mark): barrier ids are scenario-local constants
+    // with no global ordering, so "any id <= last proceeded" would let clients skip barriers in any
+    // scenario that runs after one with higher ids. The set also covers proceeds that arrive before
+    // a client starts waiting. Ids must still be globally unique across scenarios.
+    private static readonly HashSet<int> _proceeded = new();
 
     public static async UniTask Wait(ScenarioContext ctx, int barrierId, float timeoutSeconds)
     {
@@ -67,7 +71,7 @@ public static class ScenarioBarrier
         if (ctx.isClient)
         {
             await UniTaskUtils.WaitWithTimeout(
-                () => _lastProceedBarrier >= barrierId,
+                () => _proceeded.Contains(barrierId),
                 timeoutSeconds,
                 ctx.cancellationToken);
         }
@@ -83,7 +87,6 @@ public static class ScenarioBarrier
     [ObserversRpc(runLocally: true)]
     private static void BroadcastProceed(int barrierId)
     {
-        if (barrierId > _lastProceedBarrier)
-            _lastProceedBarrier = barrierId;
+        _proceeded.Add(barrierId);
     }
 }

--- a/Assets/PlayModeTests/Scripts/SerializeTests/LateSerializeScenario.cs
+++ b/Assets/PlayModeTests/Scripts/SerializeTests/LateSerializeScenario.cs
@@ -15,7 +15,7 @@ public class LateSerializeScenario : Scenario
     [SerializeField] private float _stayDisconnectedSeconds = 1.0f;
     [SerializeField] private float _barrierTimeoutSeconds = 60f;
 
-    private const int BarrierEnd = 4300;
+    private const int BarrierEnd = 4350;
 
     private LateSerializeIdentity _prefab;
 

--- a/Assets/PlayModeTests/Scripts/StateMachineTests/StateMachineServerAuthScenario.cs
+++ b/Assets/PlayModeTests/Scripts/StateMachineTests/StateMachineServerAuthScenario.cs
@@ -8,12 +8,12 @@ public class StateMachineServerAuthScenario : Scenario
     [SerializeField] private float _spawnTimeoutSeconds = 15f;
     [SerializeField] private float _stateTimeoutSeconds = 30f;
 
-    private const int BarrierInitial = 5500;
-    private const int BarrierInsertedCurrent = 5501;
-    private const int BarrierPhaseOne = 5502;
-    private const int BarrierAddedCurrent = 5503;
-    private const int BarrierFinal = 5504;
-    private const int BarrierExpandedBase = 5520;
+    private const int BarrierInitial = 6000;
+    private const int BarrierInsertedCurrent = 6001;
+    private const int BarrierPhaseOne = 6002;
+    private const int BarrierAddedCurrent = 6003;
+    private const int BarrierFinal = 6004;
+    private const int BarrierExpandedBase = 6020;
     private const float BarrierTimeoutSeconds = 60f;
 
     private StateMachineTestRig _prefab;

--- a/Assets/PurrNet/Editor/PackageManager/PurrPackageManagerInstaller.cs
+++ b/Assets/PurrNet/Editor/PackageManager/PurrPackageManagerInstaller.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -58,6 +59,60 @@ namespace PurrNet.Editor
         {
             _cachedManifest = null;
             _cachedLockFile = null;
+        }
+
+        private static string FormatInstallFailure(Exception exception, PackageInfo package)
+        {
+            var message = exception.Message;
+            if (message.IndexOf("Unity could not replace the cached package folder", StringComparison.Ordinal) >= 0)
+                return message;
+
+            if (!LooksLikePackageCacheAccessDenied(message))
+                return message;
+
+            var packageName = package?.GetUpmPackageName();
+            var cachePath = string.IsNullOrEmpty(packageName)
+                ? "Library/PackageCache/<package>@*"
+                : $"Library/PackageCache/{packageName}@*";
+
+            return message + "\n\n" +
+                   "Unity could not replace the cached package folder. On Windows this usually means " +
+                   "the current Unity session, an IDE, antivirus, or another process still has a file " +
+                   "inside the old package cache open.\n\n" +
+                   $"Close Unity, delete {cachePath}, then reopen the project and install again. " +
+                   "Removing the package, letting Unity resolve, and then adding it back also works.";
+        }
+
+        private static bool LooksLikePackageCacheAccessDenied(string message)
+        {
+            return !string.IsNullOrEmpty(message)
+                   && message.IndexOf("PackageCache", StringComparison.OrdinalIgnoreCase) >= 0
+                   && message.IndexOf("access", StringComparison.OrdinalIgnoreCase) >= 0
+                   && message.IndexOf("denied", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        public static void ResolvePackagesWithRetry(PackageInfo package = null)
+        {
+            const int maxAttempts = 3;
+            const int baseDelayMs = 750;
+
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    UnityEditor.PackageManager.Client.Resolve();
+                    return;
+                }
+                catch (Exception e) when (LooksLikePackageCacheAccessDenied(e.Message) && attempt < maxAttempts)
+                {
+                    Debug.LogWarning($"[PurrNet] Unity could not resolve packages because PackageCache is locked. Retrying ({attempt + 1}/{maxAttempts})...");
+                    Thread.Sleep(baseDelayMs * attempt);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException(FormatInstallFailure(e, package), e);
+                }
+            }
         }
 
         /// <summary>
@@ -539,8 +594,7 @@ namespace PurrNet.Editor
                         if (resolve)
                         {
                             PurrPackageManagerCache.Invalidate();
-                            UnityEditor.PackageManager.Client.Resolve();
-                            AssetDatabase.Refresh();
+                            ResolvePackagesWithRetry(package);
                         }
 
                         return Result<bool>.Ok(true);
@@ -638,8 +692,7 @@ namespace PurrNet.Editor
                 if (resolve)
                 {
                     PurrPackageManagerCache.Invalidate();
-                    UnityEditor.PackageManager.Client.Resolve();
-                    AssetDatabase.Refresh();
+                    ResolvePackagesWithRetry(package);
                 }
 
                 return Result<bool>.Ok(true);
@@ -648,6 +701,7 @@ namespace PurrNet.Editor
             {
                 Debug.LogError($"[PurrNet] Install failed: {e}");
                 EditorUtility.ClearProgressBar();
+                var message = FormatInstallFailure(e, package);
 
                 // Roll back: a partial install must not leave the project worse off than before.
                 // Remove any half-written embedded folder we created, then restore manifest/lock.
@@ -658,11 +712,10 @@ namespace PurrNet.Editor
                 if (resolve)
                 {
                     PurrPackageManagerCache.Invalidate();
-                    try { UnityEditor.PackageManager.Client.Resolve(); } catch { /* lock still held — picked up on next reload */ }
-                    AssetDatabase.Refresh();
+                    try { ResolvePackagesWithRetry(package); } catch { /* lock still held — picked up on next reload */ }
                 }
 
-                return Result<bool>.Fail(e.Message);
+                return Result<bool>.Fail(message);
             }
         }
 
@@ -682,8 +735,7 @@ namespace PurrNet.Editor
                 ClearExistingInstall(package, package.GetUpmPackageName());
 
                 PurrPackageManagerCache.Invalidate();
-                UnityEditor.PackageManager.Client.Resolve();
-                AssetDatabase.Refresh();
+                ResolvePackagesWithRetry(package);
                 return true;
             }
             catch (Exception e)
@@ -710,21 +762,21 @@ namespace PurrNet.Editor
                 if (resolve)
                 {
                     PurrPackageManagerCache.Invalidate();
-                    UnityEditor.PackageManager.Client.Resolve();
-                    AssetDatabase.Refresh();
+                    ResolvePackagesWithRetry(package);
                 }
             }
             catch (Exception e)
             {
                 EditorUtility.ClearProgressBar();
-                Debug.LogError($"[PurrNet] Failed to install external package: {e.Message}");
+                var message = FormatInstallFailure(e, package);
+                Debug.LogError($"[PurrNet] Failed to install external package: {message}");
+                EditorUtility.DisplayDialog("Install Failed", message, "Ok");
 
                 backup.Restore();
                 if (resolve)
                 {
                     PurrPackageManagerCache.Invalidate();
-                    try { UnityEditor.PackageManager.Client.Resolve(); } catch { /* lock still held — picked up on next reload */ }
-                    AssetDatabase.Refresh();
+                    try { ResolvePackagesWithRetry(package); } catch { /* lock still held — picked up on next reload */ }
                 }
             }
         }

--- a/Assets/PurrNet/Editor/PackageManager/PurrPackageManagerWindow.cs
+++ b/Assets/PurrNet/Editor/PackageManager/PurrPackageManagerWindow.cs
@@ -1588,8 +1588,7 @@ namespace PurrNet.Editor
                 }
 
                 PurrPackageManagerCache.Invalidate();
-                UnityEditor.PackageManager.Client.Resolve();
-                AssetDatabase.Refresh();
+                PurrPackageManagerInstaller.ResolvePackagesWithRetry();
             }
             catch (Exception e)
             {

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.LOD.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.LOD.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+
+namespace PurrNet
+{
+    public partial class NetworkIdentity
+    {
+        public delegate void LODTierChangedDelegate(PlayerID player, byte previousTier, byte newTier);
+
+        /// <summary>
+        /// Called when the LOD tier of this object changes for a player.
+        /// Server only.
+        /// </summary>
+        public event LODTierChangedDelegate onLODTierChanged;
+
+        private NetworkLOD _lod;
+
+        /// <summary>
+        /// The <see cref="NetworkLOD"/> component governing this identity, if any.
+        /// </summary>
+        public NetworkLOD networkLOD => _lod;
+
+        internal void SetLODComponent(NetworkLOD lod)
+        {
+            _lod = lod;
+        }
+
+        /// <summary>
+        /// Current LOD tier of this object for the given player.
+        /// 0 (full detail) when no LOD component is present. Server only.
+        /// </summary>
+        public byte GetLODTier(PlayerID player)
+        {
+            return _lod ? _lod.GetTier(player) : (byte)0;
+        }
+
+        /// <summary>
+        /// Whether state for this object should be sent to the given player on the current tick,
+        /// based on the player's LOD tier. Always true when no LOD component is present.
+        /// </summary>
+        public bool ShouldSendLODToPlayer(PlayerID player)
+        {
+            return !_lod || _lod.ShouldSendToPlayer(player);
+        }
+
+        /// <summary>
+        /// Called when the LOD tier of this object changes for a player.
+        /// Server only.
+        /// </summary>
+        /// <param name="player">The player whose tier changed</param>
+        /// <param name="previousTier">The previous tier</param>
+        /// <param name="newTier">The new tier</param>
+        protected virtual void OnLODTierChanged(PlayerID player, byte previousTier, byte newTier)
+        {
+        }
+
+        internal void TriggerOnLODTierChanged(PlayerID player, byte previousTier, byte newTier)
+        {
+            try
+            {
+                OnLODTierChanged(player, previousTier, newTier);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+
+            try
+            {
+                onLODTierChanged?.Invoke(player, previousTier, newTier);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+        }
+
+        internal void MarkLODVisibilityDirty(PlayerID player)
+        {
+            SetVisibilityDirty(player);
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.LOD.cs.meta
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.LOD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86f5cc98239b49c7ab8f828617b4e12f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD.meta
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd17209f714b43e0ae4a43e1a651cf6e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD/ILODScheduler.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD/ILODScheduler.cs
@@ -1,0 +1,25 @@
+namespace PurrNet
+{
+    /// <summary>
+    /// Decides whether an identity should send to a given player on a given tick.
+    /// The default implementation uses the profile's fixed send intervals with per-identity staggering.
+    /// </summary>
+    public interface ILODScheduler
+    {
+        bool ShouldSendThisTick(NetworkLOD lod, PlayerID player, byte tier, uint tick);
+    }
+
+    public sealed class LODIntervalScheduler : ILODScheduler
+    {
+        public static readonly LODIntervalScheduler instance = new LODIntervalScheduler();
+
+        public bool ShouldSendThisTick(NetworkLOD lod, PlayerID player, byte tier, uint tick)
+        {
+            var profile = lod.profile;
+            int interval = profile ? profile.GetSendIntervalTicks(tier) : 1;
+            if (interval <= 1)
+                return true;
+            return (tick + lod.staggerOffset) % interval == 0;
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD/ILODScheduler.cs.meta
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD/ILODScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 084a6910af46441aa2c082c14762ee72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLOD.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLOD.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PurrNet
+{
+    /// <summary>
+    /// Opt-in network LOD for the identities on this GameObject.
+    /// The server periodically resolves a tier per observer based on distance to their anchors,
+    /// which drives send-rate scheduling via <see cref="ShouldSendToPlayer"/>.
+    /// </summary>
+    public sealed class NetworkLOD : NetworkIdentity
+    {
+        [SerializeField] private NetworkLODProfile _profile;
+
+        private readonly Dictionary<PlayerID, byte> _tiers = new Dictionary<PlayerID, byte>();
+        private readonly List<NetworkIdentity> _siblings = new List<NetworkIdentity>();
+
+        public NetworkLODProfile profile
+        {
+            get => _profile;
+            set => _profile = value;
+        }
+
+        /// <summary>
+        /// Optional override for send scheduling. Defaults to <see cref="LODIntervalScheduler"/>.
+        /// </summary>
+        public ILODScheduler scheduler { get; set; }
+
+        public uint staggerOffset { get; private set; }
+
+        /// <summary>
+        /// Current tier for the given player. 0 (full detail) for owners and players not yet evaluated.
+        /// Server only; always 0 on clients.
+        /// </summary>
+        public byte GetTier(PlayerID player)
+        {
+            if (owner == player)
+                return 0;
+            return _tiers.GetValueOrDefault(player, (byte)0);
+        }
+
+        public bool IsCulled(PlayerID player)
+        {
+            return GetTier(player) == NetworkLODProfile.CulledTier;
+        }
+
+        /// <summary>
+        /// Whether a sender should include this object's state for the given player on the current tick.
+        /// Always true when no profile is assigned or the manager is unavailable.
+        /// </summary>
+        public bool ShouldSendToPlayer(PlayerID player)
+        {
+            byte tier = GetTier(player);
+
+            if (tier == NetworkLODProfile.CulledTier)
+                return false;
+
+            var nm = networkManager;
+            if (!nm)
+                return true;
+
+            var activeScheduler = scheduler ?? LODIntervalScheduler.instance;
+            return activeScheduler.ShouldSendThisTick(this, player, tier, nm.tickModule.localTick);
+        }
+
+        internal void ApplyTier(PlayerID player, byte previousTier, byte newTier)
+        {
+            _tiers[player] = newTier;
+
+            if (previousTier == newTier)
+                return;
+
+            bool cullChanged = (previousTier == NetworkLODProfile.CulledTier) !=
+                               (newTier == NetworkLODProfile.CulledTier);
+
+            for (var i = 0; i < _siblings.Count; i++)
+            {
+                var sibling = _siblings[i];
+                if (!sibling)
+                    continue;
+
+                sibling.TriggerOnLODTierChanged(player, previousTier, newTier);
+
+                if (cullChanged && _profile && _profile.cullBeyondLastTier)
+                    sibling.MarkLODVisibilityDirty(player);
+            }
+        }
+
+        internal void RemovePlayer(PlayerID player)
+        {
+            _tiers.Remove(player);
+        }
+
+        protected override void OnSpawned(bool asServer)
+        {
+            staggerOffset = id.HasValue ? (uint)(id.Value.GetHashCode() & 0x7fffffff) : 0u;
+
+            GetComponents(_siblings);
+            for (var i = 0; i < _siblings.Count; i++)
+                _siblings[i].SetLODComponent(this);
+
+            if (networkManager.TryGetModule<Modules.NetworkLODFactory>(asServer, out var factory) &&
+                factory.TryGetModule(sceneId, out var module))
+                module.Register(this);
+        }
+
+        protected override void OnDespawned(bool asServer)
+        {
+            if (asServer)
+            {
+                for (var i = 0; i < _siblings.Count; i++)
+                {
+                    if (_siblings[i])
+                        _siblings[i].SetLODComponent(null);
+                }
+
+                _siblings.Clear();
+                _tiers.Clear();
+            }
+
+            if (networkManager.TryGetModule<Modules.NetworkLODFactory>(asServer, out var factory) &&
+                factory.TryGetModule(sceneId, out var module))
+                module.Unregister(this);
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLOD.cs.meta
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLOD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 985f996009ce4f6ba2a8449a321d1724
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLODProfile.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLODProfile.cs
@@ -1,0 +1,87 @@
+using System;
+using UnityEngine;
+
+namespace PurrNet
+{
+    [Serializable]
+    public struct NetworkLODTier
+    {
+        [Tooltip("Players within this distance (and beyond the previous tier) fall into this tier.")]
+        [Min(0)] public float maxDistance;
+
+        [Tooltip("Extra distance a player must exceed before being demoted out of this tier. Prevents flapping at the boundary.")]
+        [Min(0)] public float hysteresis;
+
+        [Tooltip("How often identities in this tier send, in ticks. 1 = every tick, 2 = every other tick, etc.")]
+        [Min(1)] public int sendIntervalTicks;
+    }
+
+    [CreateAssetMenu(menuName = "PurrNet/Network LOD/LOD Profile", fileName = "New LOD Profile")]
+    public class NetworkLODProfile : ScriptableObject
+    {
+        public const byte CulledTier = byte.MaxValue;
+
+        [SerializeField]
+        private NetworkLODTier[] _tiers =
+        {
+            new NetworkLODTier { maxDistance = 30f, hysteresis = 5f, sendIntervalTicks = 1 },
+            new NetworkLODTier { maxDistance = 75f, hysteresis = 5f, sendIntervalTicks = 2 },
+            new NetworkLODTier { maxDistance = 150f, hysteresis = 10f, sendIntervalTicks = 4 }
+        };
+
+        [Tooltip("If true, players beyond the last tier stop being observers entirely. Requires a LODVisibilityRule in the active visibility rule set.")]
+        [SerializeField] private bool _cullBeyondLastTier;
+
+        public int tierCount => _tiers?.Length ?? 0;
+
+        /// <summary>
+        /// Configures the profile at runtime, for programmatically created profiles.
+        /// </summary>
+        public void Configure(NetworkLODTier[] tiers, bool cullBeyondLastTier)
+        {
+            _tiers = tiers;
+            _cullBeyondLastTier = cullBeyondLastTier;
+        }
+
+        public bool cullBeyondLastTier => _cullBeyondLastTier;
+
+        public NetworkLODTier GetTier(int index) => _tiers[index];
+
+        public int GetSendIntervalTicks(byte tier)
+        {
+            if (_tiers == null || _tiers.Length == 0 || tier == CulledTier)
+                return 1;
+            int idx = Mathf.Min(tier, _tiers.Length - 1);
+            return Mathf.Max(1, _tiers[idx].sendIntervalTicks);
+        }
+
+        /// <summary>
+        /// Resolves the tier for a given squared distance, applying hysteresis relative to the current tier.
+        /// Promotion (moving to a closer tier) uses the raw band edge; demotion requires exceeding the edge plus hysteresis.
+        /// </summary>
+        public byte ResolveTier(float sqrDistance, byte currentTier)
+        {
+            if (_tiers == null || _tiers.Length == 0)
+                return 0;
+
+            int count = _tiers.Length;
+            int current = currentTier == CulledTier ? count : currentTier;
+            int result = 0;
+
+            while (result < count)
+            {
+                float edge = _tiers[result].maxDistance;
+                if (current <= result)
+                    edge += _tiers[result].hysteresis;
+                if (sqrDistance <= edge * edge)
+                    break;
+                result++;
+            }
+
+            if (result == count)
+                return _cullBeyondLastTier ? CulledTier : (byte)(count - 1);
+
+            return (byte)result;
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLODProfile.cs.meta
+++ b/Assets/PurrNet/Runtime/Components/NetworkLOD/NetworkLODProfile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbfde3c6d0694606ac4db45704f95956
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Components/NetworkVisibility/LODVisibilityRule.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkVisibility/LODVisibilityRule.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+namespace PurrNet
+{
+    /// <summary>
+    /// Hides identities whose LOD tier for the player is culled.
+    /// Only applies to identities with a <see cref="NetworkLOD"/> component whose profile
+    /// has cullBeyondLastTier enabled; everything else stays visible.
+    /// </summary>
+    [CreateAssetMenu(menuName = "PurrNet/NetworkVisibility/LOD Rule")]
+    public class LODVisibilityRule : NetworkVisibilityRule
+    {
+        public override int complexity => 10;
+
+        public override bool CanSee(PlayerID player, NetworkIdentity target)
+        {
+            var lod = target.networkLOD;
+
+            if (!lod || !lod.profile || !lod.profile.cullBeyondLastTier)
+                return true;
+
+            return !lod.IsCulled(player);
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/Components/NetworkVisibility/LODVisibilityRule.cs.meta
+++ b/Assets/PurrNet/Runtime/Components/NetworkVisibility/LODVisibilityRule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 890ac257f60840a786157e3a9b64619f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Components/NetworkVisibility/NetworkVisibilityRuleSet.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkVisibility/NetworkVisibilityRuleSet.cs
@@ -24,10 +24,13 @@ namespace PurrNet
 
             isInitialized = true;
 
-            for (int i = 0; i < _rules.Length; i++)
+            if (_rules != null)
             {
-                _rules[i].Setup(manager);
-                _raw_rules.Add(_rules[i]);
+                for (int i = 0; i < _rules.Length; i++)
+                {
+                    _rules[i].Setup(manager);
+                    _raw_rules.Add(_rules[i]);
+                }
             }
 
             _raw_rules.Sort((a, b) =>

--- a/Assets/PurrNet/Runtime/CoreModules/NetworkLOD.meta
+++ b/Assets/PurrNet/Runtime/CoreModules/NetworkLOD.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 719a3db741ef478fb78ce970fa423f24
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODFactory.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODFactory.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PurrNet.Modules
+{
+    public class NetworkLODFactory : SceneScopedFactory<NetworkLODModule>, IFixedUpdate, IPromoteToServerModule
+    {
+        private readonly NetworkManager _manager;
+        private readonly ScenePlayersModule _scenePlayers;
+        private readonly Dictionary<PlayerID, List<Transform>> _anchors = new Dictionary<PlayerID, List<Transform>>();
+
+        /// <summary>
+        /// Maximum number of LOD-enabled identities evaluated per scene per FixedUpdate.
+        /// </summary>
+        public int sweepBudgetPerTick { get; set; } = 64;
+
+        public NetworkLODFactory(NetworkManager manager, ScenesModule scenes, ScenePlayersModule scenePlayers)
+            : base(scenes)
+        {
+            _manager = manager;
+            _scenePlayers = scenePlayers;
+        }
+
+        protected override NetworkLODModule CreateModule(SceneID scene, bool asServer)
+        {
+            return new NetworkLODModule(_manager, this, scenes, _scenePlayers, scene);
+        }
+
+        public void FixedUpdate()
+        {
+            for (var i = 0; i < modules.Count; i++)
+                modules[i].Sweep();
+        }
+
+        public void PromoteToServerModule()
+        {
+            for (var i = 0; i < modules.Count; i++)
+                modules[i].PromoteToServerModule();
+        }
+
+        public void PostPromoteToServerModule()
+        {
+            for (var i = 0; i < modules.Count; i++)
+                modules[i].PostPromoteToServerModule();
+        }
+
+        /// <summary>
+        /// Registers a transform as a distance anchor for the given player.
+        /// Registered anchors take precedence over the player's owned identities.
+        /// A player can have multiple anchors; the closest one decides the tier.
+        /// </summary>
+        public void RegisterAnchor(PlayerID player, Transform anchor)
+        {
+            if (!anchor)
+                return;
+
+            if (!_anchors.TryGetValue(player, out var list))
+            {
+                list = new List<Transform>();
+                _anchors.Add(player, list);
+            }
+
+            if (!list.Contains(anchor))
+                list.Add(anchor);
+        }
+
+        public bool UnregisterAnchor(PlayerID player, Transform anchor)
+        {
+            if (!_anchors.TryGetValue(player, out var list))
+                return false;
+
+            bool removed = list.Remove(anchor);
+
+            if (list.Count == 0)
+                _anchors.Remove(player);
+
+            return removed;
+        }
+
+        internal bool TryGetAnchors(PlayerID player, out List<Transform> anchors)
+        {
+            return _anchors.TryGetValue(player, out anchors);
+        }
+
+        internal void RemovePlayerAnchors(PlayerID player)
+        {
+            _anchors.Remove(player);
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODFactory.cs.meta
+++ b/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92002dbc056047a1af37abf07c2ec8bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODModule.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using PurrNet.Pooling;
+using UnityEngine;
+
+namespace PurrNet.Modules
+{
+    public class NetworkLODModule : INetworkModule, IPromoteToServerModule
+    {
+        private readonly List<NetworkLOD> _lods = new List<NetworkLOD>();
+        private readonly NetworkManager _manager;
+        private readonly NetworkLODFactory _factory;
+        private readonly ScenesModule _scenes;
+        private readonly ScenePlayersModule _scenePlayers;
+        private readonly SceneID _scene;
+
+        private PlayersManager _players;
+        private bool _asServer;
+        private int _sweepCursor;
+
+        public NetworkLODModule(NetworkManager manager, NetworkLODFactory factory, ScenesModule scenes,
+            ScenePlayersModule scenePlayers, SceneID scene)
+        {
+            _manager = manager;
+            _factory = factory;
+            _scenes = scenes;
+            _scenePlayers = scenePlayers;
+            _scene = scene;
+        }
+
+        public void Enable(bool asServer)
+        {
+            _asServer = asServer;
+
+            if (_manager.TryGetModule<PlayersManager>(asServer, out _players))
+                _players.onPlayerLeft += OnPlayerLeft;
+        }
+
+        public void Disable(bool asServer)
+        {
+            if (_players != null)
+                _players.onPlayerLeft -= OnPlayerLeft;
+        }
+
+        public void PromoteToServerModule()
+        {
+            _asServer = true;
+        }
+
+        public void PostPromoteToServerModule()
+        {
+        }
+
+        private void OnPlayerLeft(PlayerID player, bool asServer)
+        {
+            if (!asServer)
+                return;
+
+            for (var i = 0; i < _lods.Count; i++)
+            {
+                if (_lods[i])
+                    _lods[i].RemovePlayer(player);
+            }
+
+            _factory.RemovePlayerAnchors(player);
+        }
+
+        public void Register(NetworkLOD lod)
+        {
+            if (!_lods.Contains(lod))
+                _lods.Add(lod);
+        }
+
+        public void Unregister(NetworkLOD lod)
+        {
+            _lods.Remove(lod);
+        }
+
+        internal void Sweep()
+        {
+            if (!_asServer || _lods.Count == 0)
+                return;
+
+            if (!_scenePlayers.TryGetPlayersInScene(_scene, out var players) || players.Count == 0)
+                return;
+
+            var anchorPlayers = ListPool<PlayerID>.Instantiate();
+            var anchorPositions = ListPool<List<Vector3>>.Instantiate();
+
+            for (var i = 0; i < players.Count; i++)
+            {
+                var positions = ListPool<Vector3>.Instantiate();
+                GatherAnchorPositions(players[i], positions);
+                anchorPlayers.Add(players[i]);
+                anchorPositions.Add(positions);
+            }
+
+            int budget = Mathf.Min(_factory.sweepBudgetPerTick, _lods.Count);
+
+            for (var i = 0; i < budget; i++)
+            {
+                if (_sweepCursor >= _lods.Count)
+                    _sweepCursor = 0;
+
+                var lod = _lods[_sweepCursor++];
+
+                if (lod && lod.profile)
+                    Evaluate(lod, anchorPlayers, anchorPositions);
+            }
+
+            for (var i = 0; i < anchorPositions.Count; i++)
+                ListPool<Vector3>.Destroy(anchorPositions[i]);
+
+            ListPool<List<Vector3>>.Destroy(anchorPositions);
+            ListPool<PlayerID>.Destroy(anchorPlayers);
+        }
+
+        private static void Evaluate(NetworkLOD lod, List<PlayerID> players, List<List<Vector3>> positionsPerPlayer)
+        {
+            var lodPos = lod.transform.position;
+            var profile = lod.profile;
+
+            for (var p = 0; p < players.Count; p++)
+            {
+                var player = players[p];
+
+                if (lod.owner == player)
+                    continue;
+
+                var positions = positionsPerPlayer[p];
+                if (positions.Count == 0)
+                    continue;
+
+                float sqrMin = float.MaxValue;
+                for (var i = 0; i < positions.Count; i++)
+                {
+                    float sqr = (positions[i] - lodPos).sqrMagnitude;
+                    if (sqr < sqrMin)
+                        sqrMin = sqr;
+                }
+
+                byte current = lod.GetTier(player);
+                byte next = profile.ResolveTier(sqrMin, current);
+
+                if (next != current)
+                    lod.ApplyTier(player, current, next);
+            }
+        }
+
+        private void GatherAnchorPositions(PlayerID player, List<Vector3> positions)
+        {
+            bool hasScene = _scenes.TryGetSceneState(_scene, out var sceneState);
+
+            if (_factory.TryGetAnchors(player, out var anchors))
+            {
+                for (var i = 0; i < anchors.Count; i++)
+                {
+                    var anchor = anchors[i];
+                    if (anchor && (!hasScene || anchor.gameObject.scene == sceneState.scene))
+                        positions.Add(anchor.position);
+                }
+
+                if (positions.Count > 0)
+                    return;
+            }
+
+            foreach (var owned in _manager.EnumerateAllPlayerOwnedIds(player, true))
+            {
+                if (owned && owned.isActiveAndEnabled && owned.sceneId == _scene)
+                    positions.Add(owned.transform.position);
+            }
+        }
+    }
+}

--- a/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODModule.cs.meta
+++ b/Assets/PurrNet/Runtime/CoreModules/NetworkLOD/NetworkLODModule.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f71f3cc2bbf145708fca3130cbf6d51f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -938,6 +938,13 @@ namespace PurrNet
         public DeltaModule deltaModule => _serverDeltaModule ?? _clientDeltaModule;
 
         /// <summary>
+        /// The network LOD factory of the network manager.
+        /// Defaults to the server module if the server is active.
+        /// Otherwise it defaults to the client module.
+        /// </summary>
+        public NetworkLODFactory lodModule => _serverLODModule ?? _clientLODModule;
+
+        /// <summary>
         /// The local player of the network manager.
         /// If the local player is not set, this will return the default value of the player id.
         /// </summary>
@@ -980,6 +987,9 @@ namespace PurrNet
 
         internal DeltaModule _clientDeltaModule;
         internal DeltaModule _serverDeltaModule;
+
+        private NetworkLODFactory _clientLODModule;
+        private NetworkLODFactory _serverLODModule;
 
         private AuthModule _serverAuthModule;
 
@@ -1269,6 +1279,10 @@ namespace PurrNet
             var networkTransform =
                 new NetworkTransformFactory(scenesModule, scenePlayers, playersBroadcast, this, hierarchyV2);
             var colliderRollback = new ColliderRollbackFactory(tickManager, scenesModule);
+            var networkLOD = new NetworkLODFactory(this, scenesModule, scenePlayers);
+
+            if (asServer) _serverLODModule = networkLOD;
+            else _clientLODModule = networkLOD;
 
             if (asServer)
                 _serverRpcModule = rpcModule;
@@ -1289,6 +1303,7 @@ namespace PurrNet
             modules.AddModule(rpcModule);
             modules.AddModule(new RpcRequestResponseModule(this, playersManager, asServer));
             modules.AddModule(colliderRollback);
+            modules.AddModule(networkLOD);
 
 #if ADDRESSABLES_PURRNET_SUPPORT
             if (_addressableNetworkPrefabs && _addressableNetworkPrefabs.count > 0 &&
@@ -1881,6 +1896,7 @@ namespace PurrNet
             _serverScenePlayersModule = null;
             _serverDeltaModule = null;
             _serverRpcModule = null;
+            _serverLODModule = null;
         }
 
         public void InternalUnregisterClientModules()
@@ -1914,6 +1930,7 @@ namespace PurrNet
             _clientScenePlayersModule = null;
             _clientDeltaModule = null;
             _clientRpcModule = null;
+            _clientLODModule = null;
         }
 
         private Coroutine _clientCoroutine;


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784204480&installation_id=129033668&pr_number=261&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F261&signature=7a6a32bcaf7a08d391c14b7b9c537f52dfc90b40fd9cd1d2d516af8295f444dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Network Level-of-Detail (LOD) system enabling server-controlled per-player tier management and send frequency optimization based on distance
  * Added LOD visibility rules for distance-based entity culling
  * Added package manager automatic retry on cache lock failures

* **Bug Fixes**
  * Fixed null reference handling in visibility rule initialization
  * Fixed barrier synchronization logic in multi-client test scenarios

* **Tests**
  * Added comprehensive LOD tier and culling test scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->