### PR TITLE
fix: sync types stop firing onChanged callback after recycled from pool

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -1333,7 +1333,7 @@ namespace PurrNet
             }
         }
 
-        internal void TriggerDespawnEvent(bool asServer)
+        internal void TriggerDespawnEvent(bool asServer, bool preserveModules = false)
         {
             if (!IsSpawned(asServer)) return;
 
@@ -1393,7 +1393,7 @@ namespace PurrNet
 
             RecacheHasConnectedOwner();
 
-            if (_spawnedCount == 0)
+            if (_spawnedCount == 0 && !preserveModules)
             {
                 _externalModulesView.Clear();
                 _modules.Clear();

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -1678,22 +1678,37 @@ namespace PurrNet.Modules
             if (_asServer)
             {
                 _visibility.ClearVisibilityForGameObject(gameObject.transform);
+                
                 for (var i = 0; i < c; i++)
-                    TriggerDespawnEvent(children[i]);
+                {
+                    var child = children[i];
+                    
+                    TriggerDespawnEvent(child, child.shouldBePooled);
+                }
+
                 _manager.FlushBatchedRPCs();
                 FlushSpawnPackets();
             }
             else if (!bypassBroadcast)
             {
                 for (var i = 0; i < c; i++)
-                    TriggerDespawnEvent(children[i]);
+                {
+                    var child = children[i];
+                    
+                    TriggerDespawnEvent(child, child.shouldBePooled);
+                }
+
                 _manager.FlushBatchedRPCs();
                 SendDespawnPacket(default, children[0], false);
             }
             else
             {
                 for (var i = 0; i < c; i++)
-                    TriggerDespawnEvent(children[i]);
+                {
+                    var child = children[i];
+                    
+                    TriggerDespawnEvent(child, child.shouldBePooled);
+                }
             }
 
             for (var i = 0; i < c; i++)
@@ -2192,11 +2207,11 @@ namespace PurrNet.Modules
             }
         }
 
-        private void TriggerDespawnEvent(NetworkIdentity identity)
+        private void TriggerDespawnEvent(NetworkIdentity identity, bool preserveModules = false)
         {
             if (_asServer && IsServerHost())
-                identity.TriggerDespawnEvent(false);
-            identity.TriggerDespawnEvent(_asServer);
+                identity.TriggerDespawnEvent(false, preserveModules);
+            identity.TriggerDespawnEvent(_asServer, preserveModules);
         }
 
         private void UnregisterIdentity(NetworkIdentity identity)


### PR DESCRIPTION
`SyncVar.onChanged` stops firing on pooled objects after all prewarmed instances have been recycled once.

## Conditions

- PurrNet pooling enabled
- Pool prewarm count: `5`
- Spawn object
- Set SyncVar payload immediately after `Instantiate`
- Despawn object
- Repeat until spawning beyond the 5 prewarmed instances

## Spawn Code

```csharp
var instance = Instantiate(definition.Prefab, position, rotation);
instance.GetComponent<PerspectiveParent>().SetPayload(new PerspectiveParent.Payload(this, SlotType.Hand));
```

## Component Code

```csharp
private readonly SyncVar<Payload> _payload = new(ownerAuth: true);

protected override void OnEarlySpawn()
{
    _payload.onChanged += OnPayloadChanged;
}

protected override void OnDespawned()
{
    _payload.onChanged -= OnPayloadChanged;
}

public void SetPayload(Payload payload)
{
    _payload.value = payload;
}

private void OnPayloadChanged(Payload payload)
{
    ApplyPayload(payload);
}
```

## Observed Behavior

- First 5 spawned instances work correctly.
- After those 5 instances are despawned and reused from the pool, `SetPayload(...)` is called but `_payload.onChanged` no longer fires.
- Same issue happens with other scripts using sync callbacks, not only this component.
- If pooling is disabled, the issue does not happen.

## Expected Behavior

`onChanged` should fire when setting a new SyncVar value after a pooled object is reused, same as it does on the first spawn and when pooling is disabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784904450&installation_id=129033668&pr_number=263&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F263&signature=c81968a72dfa26dc6a1567b91e34950446d2c3f89b28be6c838bf267c01299ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved despawn behavior so pooled entities can keep their internal modules intact when needed.
  * Child entities now follow the correct despawn handling more consistently across different network paths.
  * Reduced unwanted clearing of entity state during final despawn, helping preserve expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->