### PR TITLE
sync types use on serialize and on deserialize for initial spawn

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/NetworkIdentity.cs
@@ -247,6 +247,8 @@ namespace PurrNet
 
         Queue<Action> _onSpawnedQueue;
 
+        public bool observerSpawnStateIncluded { get; private set; }
+
         /// <summary>
         /// Returns if you can control this object.
         /// If the object has an owner, it will return if you are the owner.
@@ -1539,6 +1541,25 @@ namespace PurrNet
         }
 
         public void TriggerOnObserverAdded(PlayerID target, bool isSpawner)
+        {
+            TriggerOnObserverAdded(target, isSpawner, false);
+        }
+
+        public void TriggerOnObserverAdded(PlayerID target, bool isSpawner, bool spawnStateIncluded)
+        {
+            observerSpawnStateIncluded = spawnStateIncluded;
+
+            try
+            {
+                TriggerOnObserverAddedInternal(target, isSpawner);
+            }
+            finally
+            {
+                observerSpawnStateIncluded = false;
+            }
+        }
+
+        private void TriggerOnObserverAddedInternal(PlayerID target, bool isSpawner)
         {
             try
             {

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/NetworkModule.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/NetworkModule.cs
@@ -45,6 +45,8 @@ namespace PurrNet
 
         public bool isController => parent && parent.isController;
 
+        public bool observerSpawnStateIncluded => parent && parent.observerSpawnStateIncluded;
+
         [UsedImplicitly]
         public bool IsController(bool ownerHasAuthority) => parent && parent.IsController(ownerHasAuthority);
 

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -136,6 +136,9 @@ namespace PurrNet
 
         public override void OnObserverAdded(PlayerID player, bool isSpawner)
         {
+            if (observerSpawnStateIncluded)
+                return;
+
             if (isSpawner && ownerAuth && owner == player)
                 return;
 
@@ -155,6 +158,23 @@ namespace PurrNet
         public override void OnSpawn()
         {
             InvalidateIsController();
+        }
+
+        public override void OnSerialize(BitPacker packer)
+        {
+            Packer<T>.Write(packer, _value);
+        }
+
+        public override void OnDeserialize(BitPacker packer)
+        {
+            var oldValue = _value;
+            var newValue = default(T);
+            Packer<T>.Read(packer, ref newValue);
+
+            if (!Packer.Transform(ref _value, newValue))
+                return;
+
+            TriggerEvents(oldValue);
         }
 
         private void InvalidateIsController()

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -726,7 +726,7 @@ namespace PurrNet.Modules
                                 if (!nid.IsObserver(spawner)) continue;
                                 onObserverAdded?.Invoke(spawner, nid);
                                 nid.TriggerOnPreObserverAdded(spawner, true);
-                                _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true, spawnStateIncluded = true });
+                                _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true, spawnStateIncluded = false });
                             }
 
                             var lastNid = list[count - 1];
@@ -829,7 +829,7 @@ namespace PurrNet.Modules
                             if (!nid.IsObserver(spawner)) continue;
                             onObserverAdded?.Invoke(spawner, nid);
                             nid.TriggerOnPreObserverAdded(spawner, true);
-                            _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true, spawnStateIncluded = true });
+                            _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true, spawnStateIncluded = false });
                         }
 
                         var lastNid = list[count - 1];
@@ -1344,7 +1344,7 @@ namespace PurrNet.Modules
                         var nid = children[i];
                         onObserverAdded?.Invoke(player, nid);
                         nid.TriggerOnPreObserverAdded(player, false);
-                        _triggerLateObserverAdded.Add(new PlayerNid { player = player, nid = nid, isSpawner = false, spawnStateIncluded = sentSpawnPacket });
+                        _triggerLateObserverAdded.Add(new PlayerNid { player = player, nid = nid, isSpawner = false, spawnStateIncluded = false });
                     }
                 }
                 else PurrLogger.LogError($"Failed to get prototype for '{scope.name}'.", scope);

--- a/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs
@@ -726,7 +726,7 @@ namespace PurrNet.Modules
                                 if (!nid.IsObserver(spawner)) continue;
                                 onObserverAdded?.Invoke(spawner, nid);
                                 nid.TriggerOnPreObserverAdded(spawner, true);
-                                _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true });
+                                _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true, spawnStateIncluded = true });
                             }
 
                             var lastNid = list[count - 1];
@@ -776,7 +776,7 @@ namespace PurrNet.Modules
                 var entry = _triggerLateObserverAdded[i];
                 if (!ListContainsNid(list, entry.nid)) continue;
                 if (!entry.nid || !entry.nid.isSpawned) continue;
-                entry.nid.TriggerOnObserverAdded(entry.player, entry.isSpawner);
+                entry.nid.TriggerOnObserverAdded(entry.player, entry.isSpawner, entry.spawnStateIncluded);
                 onLateObserverAdded?.Invoke(entry.player, entry.nid);
             }
             for (int i = _triggerLateObserverAdded.Count - 1; i >= 0; i--)
@@ -829,7 +829,7 @@ namespace PurrNet.Modules
                             if (!nid.IsObserver(spawner)) continue;
                             onObserverAdded?.Invoke(spawner, nid);
                             nid.TriggerOnPreObserverAdded(spawner, true);
-                            _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true });
+                            _triggerLateObserverAdded.Add(new PlayerNid { player = spawner, nid = nid, isSpawner = true, spawnStateIncluded = true });
                         }
 
                         var lastNid = list[count - 1];
@@ -1311,6 +1311,7 @@ namespace PurrNet.Modules
             public PlayerID player;
             public NetworkIdentity nid;
             public bool isSpawner;
+            public bool spawnStateIncluded;
         }
 
         private readonly List<PlayerNid> _triggerLateObserverAdded = new List<PlayerNid>();
@@ -1332,7 +1333,8 @@ namespace PurrNet.Modules
                 var children = ListPool<NetworkIdentity>.Instantiate();
                 if (HierarchyPool.TryGetPrototype(scope, player, children, out var prototype))
                 {
-                    if (_scenePlayers.IsPlayerLoadedInScene(player, _sceneId))
+                    var sentSpawnPacket = _scenePlayers.IsPlayerLoadedInScene(player, _sceneId);
+                    if (sentSpawnPacket)
                     {
                         SendSpawnPacket(player, prototype, children, true);
                     }
@@ -1342,7 +1344,7 @@ namespace PurrNet.Modules
                         var nid = children[i];
                         onObserverAdded?.Invoke(player, nid);
                         nid.TriggerOnPreObserverAdded(player, false);
-                        _triggerLateObserverAdded.Add(new PlayerNid { player = player, nid = nid, isSpawner = false });
+                        _triggerLateObserverAdded.Add(new PlayerNid { player = player, nid = nid, isSpawner = false, spawnStateIncluded = sentSpawnPacket });
                     }
                 }
                 else PurrLogger.LogError($"Failed to get prototype for '{scope.name}'.", scope);
@@ -1859,7 +1861,7 @@ namespace PurrNet.Modules
                 if (!nid.nid || !nid.nid.isSpawned)
                     continue;
 
-                nid.nid.TriggerOnObserverAdded(nid.player, nid.isSpawner);
+                nid.nid.TriggerOnObserverAdded(nid.player, nid.isSpawner, nid.spawnStateIncluded);
                 onLateObserverAdded?.Invoke(nid.player, nid.nid);
             }
 
@@ -1912,7 +1914,7 @@ namespace PurrNet.Modules
                 {
                     onObserverAdded?.Invoke(playerId, identity);
                     identity.TriggerOnPreObserverAdded(playerId, false);
-                    _triggerLateObserverAdded.Add(new PlayerNid { player = playerId, nid = identity, isSpawner = false });
+                    _triggerLateObserverAdded.Add(new PlayerNid { player = playerId, nid = identity, isSpawner = false, spawnStateIncluded = false });
                 }
 
                 identity.TriggerSpawnEvent(false);


### PR DESCRIPTION
PurrNet version: 1.20.0-beta.228

There's a bug with client-spawned objects and owner-auth `SyncVar`s.

Basically, a non-host client creates an item, sets some SyncVars, then spawns it:

```csharp
var instance = UnityProxy.InstantiateDirectly(definition.Prefab, position, rotation)
    .GetComponent<NetworkItem>();

instance.SetPayload(payload);
instance.Spawn(definition.Prefab, networkManager);
instance.GiveOwnership(networkManager.localPlayer, false, true);
```

```csharp
private readonly SyncVar<State> _state = new(State.Grounded, ownerAuth: true);
private readonly SyncVar<ItemReference> _reference = new(ownerAuth: true);

public void SetPayload(Payload payload)
{
    _state.value = payload.State;
    _reference.value = payload.Reference;
}
```

What I get:

- Spawning client sees the correct item state.
- Host/server and other clients get default/stale values.
- If host does the same thing, it works fine.

What I expected:

If client spawning is allowed, and the client is going to own the object, SyncVars set before `Spawn` should be included in the initial spawn data somehow.

Fix idea that I decided to test in my branch:

- SyncTypes serialize their initial values through `OnSerialize` / `OnDeserialize`.
- `OnObserverAdded` skips its initial SyncType send when that data was already included in the spawn packet.
- Add something like `UnityProxy.InstantiateWithSetup(...)`, so setup can run before PurrNet builds the spawn packet. (not implemented yet)

Example:

```csharp
var item = UnityProxy.InstantiateWithSetup(definition.Prefab, position, rotation, instance =>
{
    instance.GetComponent<NetworkItem>().SetPayload(payload);
});
```

Manual spawn would also work cleanly:

```csharp
var instance = UnityProxy.InstantiateDirectly(definition.Prefab, position, rotation);
var item = instance.GetComponent<NetworkItem>();

item.SetPayload(payload);
item.Spawn(definition.Prefab, networkManager);
```

Main benefits:

- no need to manually call `OnSerialize` / `OnDeserialize` inside every `NetworkBehaviour` to avoid delay issues
- SyncVars are available immediately on spawn of an object
- existing auto-spawn flow still keep the old delayed SyncVar update behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784982399&installation_id=129033668&pr_number=264&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F264&signature=30e35fc82abb1369647308441223a20ff68f486f53a80e2d7c7c867618b9586b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking whether observer updates include spawn-state information, and propagating this context through late, delayed, and buffered observer notifications.

* **Bug Fixes**
  * Prevents redundant state syncing when the observer has already received spawn-state data.
  * Improves network value serialization/deserialization so changes are applied safely and change notifications fire only after successful updates.
  * Ensures observer notifications consistently carry the correct spawn-state context across delayed and buffered scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->