### PR TITLE
fix: defer NetworkOwnershipToggle refresh to LateUpdate

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
@@ -33,12 +33,21 @@ namespace PurrNet
             RequestRefresh();
         }
 
+        protected override void OnDespawned()
+        {
+            _refreshPending = false;
+        }
+
         private void LateUpdate()
         {
             if (!_refreshPending)
                 return;
 
             _refreshPending = false;
+
+            if (!isSpawned)
+                return;
+
             Refresh();
         }
 

--- a/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
@@ -12,6 +12,8 @@ namespace PurrNet
         [SerializeField] private OwnershipComponentToggle[] _components;
         [Tooltip("GameObjects to toggle from the owner's perspective")]
         [SerializeField] private OwnershipGameObjectToggle[] _gameObjects;
+        [Tooltip("Apply the final controller state in LateUpdate to avoid transient ownership changes during spawning")]
+        [SerializeField] private bool _applyInLateUpdate;
 
         [SerializeField, HideInInspector] private GameObject[] _toActivate;
         [SerializeField, HideInInspector] private GameObject[] _toDeactivate;
@@ -19,6 +21,7 @@ namespace PurrNet
         [SerializeField, HideInInspector] private Behaviour[] _toDisable;
 
         private bool _lastIsController;
+        private bool _refreshPending;
 
         private void Awake()
         {
@@ -27,8 +30,34 @@ namespace PurrNet
 
         protected override void OnSpawned()
         {
-            if (isController)
-                Setup(true);
+            RequestRefresh();
+        }
+
+        private void LateUpdate()
+        {
+            if (!_refreshPending)
+                return;
+
+            _refreshPending = false;
+            Refresh();
+        }
+
+        private void RequestRefresh()
+        {
+            if (_applyInLateUpdate)
+            {
+                _refreshPending = true;
+                return;
+            }
+
+            Refresh();
+        }
+
+        private void Refresh()
+        {
+            bool controller = isController;
+            if (controller != _lastIsController)
+                Setup(controller);
         }
 
         // migrate old data to _components and _gameObjects
@@ -140,16 +169,12 @@ namespace PurrNet
 
         protected override void OnOwnerReconnected(PlayerID ownerId)
         {
-            bool controller = isController;
-            if (controller != _lastIsController)
-                Setup(controller);
+            RequestRefresh();
         }
 
         protected override void OnOwnerChanged(PlayerID? oldOwner, PlayerID? newOwner, bool asServer)
         {
-            bool controller = isController;
-            if (controller != _lastIsController)
-                Setup(controller);
+            RequestRefresh();
         }
     }
 }


### PR DESCRIPTION
# Fix transient NetworkOwnershipToggle activation during player spawning

## Summary

Adds an optional `Apply In Late Update` mode to `NetworkOwnershipToggle`.

When enabled, ownership changes occurring within the same frame are coalesced and the final `isController` state is applied once during `LateUpdate`.

The existing immediate behavior remains unchanged by default.

## Problem

When `PlayerSpawner` creates a remote player on a host, the spawn pipeline temporarily assigns ownership to the host before `PlayerSpawner` calls `GiveOwnership(player)` for the actual remote client.

Both ownership changes happen during the same frame:

1. `HierarchyV2.AutoAssignOwnership` temporarily assigns the host.
2. `NetworkOwnershipToggle.OnOwnerChanged` enables owner/controller-only components.
3. `PlayerSpawner` assigns the remote client as the final owner.
4. The components are disabled again.

This causes components such as local player input or cameras to receive an unnecessary `OnEnable` / `OnDisable` cycle during spawning.

In the reported case, a `FirstPersonInput` component briefly enabled on the host for a remote player and disabled a shared `InputActionAsset`, causing the host player to lose input.

## Solution

The new optional mode:

* queues ownership refreshes during the current frame;
* applies only the final `isController` state in `LateUpdate`;
* avoids unnecessary component and GameObject state assignments;
* resets pending state when the object is despawned;
* preserves the original immediate behavior when the option is disabled.

## Testing

Tested with Unity Multiplayer Play Mode using:

* one host/client instance;
* two additional client instances;
* a player prefab with input, character controller, camera, and local objects managed by `NetworkOwnershipToggle`.

Results with `Apply In Late Update` enabled:

* remote player input is no longer briefly enabled on the host;
* the host retains input when additional clients connect;
* each client controls only its own player;
* connecting a third client does not affect existing players.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785264786&installation_id=129033668&pr_number=265&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F265&signature=c203af837541af1a4ae046eae16e74231a2a8aef0b94c5fc659cca031a0601a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed brief incorrect enabled/activation states caused by ownership changes during spawning.
  * Improved ownership state transitions by optionally deferring ownership-driven updates until after initial spawn setup completes.
  * Avoided redundant reconfiguration by only applying changes when the controller-related state has actually changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->