### PR TITLE
Added InstantiateDirectlyFromPool

### DIFF
--- a/Assets/PurrNet/Runtime/UnityProxy/UnityProxy.cs
+++ b/Assets/PurrNet/Runtime/UnityProxy/UnityProxy.cs
@@ -27,7 +27,7 @@ namespace PurrNet
             };
         }
 
-        static T OnPreInstantiate<T>(PrefabData prefabData, InstantiateData<T> instantiateData, bool notifyCreated)
+        static T OnPreInstantiate<T>(PrefabData prefabData, InstantiateData<T> instantiateData, bool notifyCreated = true)
             where T : Object
         {
             var prefab = prefabData.prefab;
@@ -38,14 +38,22 @@ namespace PurrNet
             if (!prefabData.pooled)
             {
                 var instance = instantiateData.Instantiate();
-                NotifyGameObjectCreated(instance, prefab, notifyCreated);
+                if (notifyCreated)
+                {
+                    var go = GetGameObject(instance);
+                    PurrNetGameObjectUtils.NotifyGameObjectCreated(go, prefab);
+                }
                 return instance;
             }
 
             if (!HierarchyPool.TryGetPrefabPrototype(prefab, out var prototype))
             {
                 var instance = instantiateData.Instantiate();
-                NotifyGameObjectCreated(instance, prefab, notifyCreated);
+                if (notifyCreated)
+                {
+                    var go = GetGameObject(instance);
+                    PurrNetGameObjectUtils.NotifyGameObjectCreated(go, prefab);
+                }
                 return instance;
             }
 
@@ -62,38 +70,14 @@ namespace PurrNet
             }
 
             instantiateData.ApplyToExisting(result, prefab);
-            NotifyGameObjectCreated(result, prefab, notifyCreated);
+
+            if (notifyCreated)
+                PurrNetGameObjectUtils.NotifyGameObjectCreated(result, prefab);
 
             if (result.TryGetComponent(out T component))
                 return component;
 
             return (T)(Object)result;
-        }
-
-        static void NotifyGameObjectCreated<T>(T instance, GameObject prefab, bool notifyCreated) where T : Object
-        {
-            if (!notifyCreated)
-                return;
-
-            var go = GetGameObject(instance);
-            PurrNetGameObjectUtils.NotifyGameObjectCreated(go, prefab);
-        }
-
-        static T InstantiateWithPurrNet<T>(T original, InstantiateData<T> instantiateData) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return instantiateData.Instantiate();
-
-            return OnPreInstantiate(prefabData, instantiateData, true);
-        }
-
-        static T InstantiateDirectlyFromPoolWithPurrNet<T>(T original, InstantiateData<T> instantiateData)
-            where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return instantiateData.Instantiate();
-
-            return OnPreInstantiate(prefabData, instantiateData, false);
         }
 
         static bool OnDestroy(Object instance)
@@ -186,39 +170,61 @@ namespace PurrNet
         [UsedByIL]
         public static Object InstantiateDirectly(Object original) => Object.Instantiate(original);
 
+        public static Object InstantiateDirectlyFromPool(Object original)
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original);
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original), false);
+        }
+
         [UsedByIL]
         public static Object Instantiate(Object original)
-            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original));
-
-        public static Object InstantiateDirectlyFromPool(Object original)
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<Object>(original));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original);
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original));
+        }
 
         [UsedByIL]
         public static Object Instantiate(Object original, Transform parent, bool instantiateInWorldSpace)
-            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, parent, instantiateInWorldSpace));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent, instantiateInWorldSpace);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, parent, instantiateInWorldSpace));
+        }
 
         public static Object InstantiateDirectly(Object original, Transform parent, bool instantiateInWorldSpace)
             => Object.Instantiate(original, parent, instantiateInWorldSpace);
 
-        public static Object InstantiateDirectlyFromPool(
-            Object original,
-            Transform parent,
-            bool instantiateInWorldSpace)
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<Object>(original, parent, instantiateInWorldSpace));
+        public static Object InstantiateDirectlyFromPool(Object original, Transform parent, bool instantiateInWorldSpace)
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent, instantiateInWorldSpace);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, parent, instantiateInWorldSpace),
+                false);
+        }
 
         [UsedByIL]
         public static Object Instantiate(Object original, Vector3 position, Quaternion rotation)
-            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, position, rotation));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, position, rotation));
+        }
 
         public static Object InstantiateDirectly(Object original, Vector3 position, Quaternion rotation)
             => Object.Instantiate(original, position, rotation);
 
         public static Object InstantiateDirectlyFromPool(Object original, Vector3 position, Quaternion rotation)
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<Object>(original, position, rotation));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, position, rotation), false);
+        }
 
         [UsedByIL]
         public static Object Instantiate(
@@ -226,7 +232,12 @@ namespace PurrNet
             Vector3 position,
             Quaternion rotation,
             Transform parent)
-            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, position, rotation, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, position, rotation, parent));
+        }
 
         public static Object InstantiateDirectly(
             Object original,
@@ -242,95 +253,164 @@ namespace PurrNet
             Vector3 position,
             Quaternion rotation,
             Transform parent)
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<Object>(original, position, rotation, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, position, rotation, parent),
+                false);
+        }
 
 #if UNITY_2023_1_OR_NEWER
         [UsedByIL]
         public static Object Instantiate(Object original, Scene scene)
-            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, scene));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, scene);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, scene));
+        }
 
         public static Object InstantiateDirectly(Object original, Scene scene)
             => Object.Instantiate(original, scene);
 
         public static Object InstantiateDirectlyFromPool(Object original, Scene scene)
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<Object>(original, scene));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, scene);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, scene), false);
+        }
 
         public static T InstantiateDirectly<T>(T original, Scene scene) where T : Object
             => (T)Object.Instantiate(original, scene);
 
         public static T InstantiateDirectlyFromPool<T>(T original, Scene scene) where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original, scene));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return InstantiateDirectly(original, scene);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, scene), false);
+        }
 #endif
 
         [UsedByIL]
         public static Object Instantiate(Object original, Transform parent)
-            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, parent));
+        }
 
         public static Object InstantiateDirectly(Object original, Transform parent)
             => Object.Instantiate(original, parent);
 
         public static Object InstantiateDirectlyFromPool(Object original, Transform parent)
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<Object>(original, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, parent), false);
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(T original) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original));
+        }
 
 #if UNITY_6000_0_OR_NEWER
         [UsedByIL]
         public static T Instantiate<T>(T original, InstantiateParameters parameters) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, parameters));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parameters);
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parameters));
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(T original, Vector3 pos, Quaternion rot, InstantiateParameters parameters) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, pos, rot, parameters));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, pos, rot, parameters);
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, pos, rot, parameters));
+        }
 
         [UsedByIL]
         public static T InstantiateDirectly<T>(T original, InstantiateParameters parameters) where T : Object
             => Object.Instantiate(original, parameters);
 
         public static T InstantiateDirectlyFromPool<T>(T original, InstantiateParameters parameters) where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original, parameters));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parameters);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parameters), false);
+        }
 
         [UsedByIL]
         public static T InstantiateDirectly<T>(T original, Vector3 pos, Quaternion rot, InstantiateParameters parameters) where T : Object
             => Object.Instantiate(original, pos, rot, parameters);
 
-        public static T InstantiateDirectlyFromPool<T>(
-            T original,
-            Vector3 pos,
-            Quaternion rot,
-            InstantiateParameters parameters)
-            where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<T>(original, pos, rot, parameters));
+        public static T InstantiateDirectlyFromPool<T>(T original, Vector3 pos, Quaternion rot, InstantiateParameters parameters) where T : Object
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, pos, rot, parameters);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, pos, rot, parameters), false);
+        }
 #endif
 
         public static T InstantiateDirectly<T>(T original) where T : Object
             => Object.Instantiate(original);
 
         public static T InstantiateDirectlyFromPool<T>(T original) where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original), false);
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(T original, Vector3 position, Quaternion rotation) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, position, rotation));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation));
+        }
 
         public static T InstantiateDirectly<T>(T original, Vector3 position, Quaternion rotation) where T : Object
             => Object.Instantiate(original, position, rotation);
 
-        public static T InstantiateDirectlyFromPool<T>(T original, Vector3 position, Quaternion rotation)
-            where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<T>(original, position, rotation));
+        public static T InstantiateDirectlyFromPool<T>(T original, Vector3 position, Quaternion rotation) where T : Object
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation), false);
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(T original, Vector3 position, Quaternion rotation, Scene scene) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, position, rotation, scene));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+            {
+                var obj = Object.Instantiate(original, position, rotation);
+                var go = GetGameObject(obj);
+
+                if (go && go.scene.handle != scene.handle)
+                    SceneManager.MoveGameObjectToScene(go, scene);
+                return obj;
+            }
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation, scene));
+        }
 
         public static T InstantiateDirectly<T>(T original, Vector3 position, Quaternion rotation, Scene scene)
             where T : Object
@@ -342,15 +422,14 @@ namespace PurrNet
             return obj;
         }
 
-        public static T InstantiateDirectlyFromPool<T>(
-            T original,
-            Vector3 position,
-            Quaternion rotation,
-            Scene scene)
+        public static T InstantiateDirectlyFromPool<T>(T original, Vector3 position, Quaternion rotation, Scene scene)
             where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<T>(original, position, rotation, scene));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return InstantiateDirectly(original, position, rotation, scene);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation, scene), false);
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(
@@ -359,7 +438,12 @@ namespace PurrNet
             Quaternion rotation,
             Transform parent)
             where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, position, rotation, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation, parent));
+        }
 
         public static T InstantiateDirectly<T>(
             T original,
@@ -375,32 +459,53 @@ namespace PurrNet
             Quaternion rotation,
             Transform parent)
             where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<T>(original, position, rotation, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, position, rotation, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation, parent), false);
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(T original, Transform parent) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parent));
+        }
 
         public static T InstantiateDirectly<T>(T original, Transform parent) where T : Object
             => Object.Instantiate(original, parent);
 
         public static T InstantiateDirectlyFromPool<T>(T original, Transform parent) where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original, parent));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parent), false);
+        }
 
         [UsedByIL]
         public static T Instantiate<T>(T original, Transform parent, bool worldPositionStays) where T : Object
-            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, parent, worldPositionStays));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent, worldPositionStays);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parent, worldPositionStays));
+        }
 
         public static T InstantiateDirectly<T>(T original, Transform parent, bool worldPositionStays) where T : Object
             => Object.Instantiate(original, parent, worldPositionStays);
 
         public static T InstantiateDirectlyFromPool<T>(T original, Transform parent, bool worldPositionStays)
             where T : Object
-            => InstantiateDirectlyFromPoolWithPurrNet(
-                original,
-                new InstantiateData<T>(original, parent, worldPositionStays));
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return Object.Instantiate(original, parent, worldPositionStays);
+
+            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parent, worldPositionStays), false);
+        }
 
         [UsedByIL]
         public static void Destroy(Object obj)

--- a/Assets/PurrNet/Runtime/UnityProxy/UnityProxy.cs
+++ b/Assets/PurrNet/Runtime/UnityProxy/UnityProxy.cs
@@ -27,7 +27,7 @@ namespace PurrNet
             };
         }
 
-        static T OnPreInstantiate<T>(PrefabData prefabData, InstantiateData<T> instantiateData)
+        static T OnPreInstantiate<T>(PrefabData prefabData, InstantiateData<T> instantiateData, bool notifyCreated)
             where T : Object
         {
             var prefab = prefabData.prefab;
@@ -38,16 +38,14 @@ namespace PurrNet
             if (!prefabData.pooled)
             {
                 var instance = instantiateData.Instantiate();
-                var go = GetGameObject(instance);
-                PurrNetGameObjectUtils.NotifyGameObjectCreated(go, prefab);
+                NotifyGameObjectCreated(instance, prefab, notifyCreated);
                 return instance;
             }
 
             if (!HierarchyPool.TryGetPrefabPrototype(prefab, out var prototype))
             {
                 var instance = instantiateData.Instantiate();
-                var go = GetGameObject(instance);
-                PurrNetGameObjectUtils.NotifyGameObjectCreated(go, prefab);
+                NotifyGameObjectCreated(instance, prefab, notifyCreated);
                 return instance;
             }
 
@@ -64,12 +62,38 @@ namespace PurrNet
             }
 
             instantiateData.ApplyToExisting(result, prefab);
-            PurrNetGameObjectUtils.NotifyGameObjectCreated(result, prefab);
+            NotifyGameObjectCreated(result, prefab, notifyCreated);
 
             if (result.TryGetComponent(out T component))
                 return component;
 
             return (T)(Object)result;
+        }
+
+        static void NotifyGameObjectCreated<T>(T instance, GameObject prefab, bool notifyCreated) where T : Object
+        {
+            if (!notifyCreated)
+                return;
+
+            var go = GetGameObject(instance);
+            PurrNetGameObjectUtils.NotifyGameObjectCreated(go, prefab);
+        }
+
+        static T InstantiateWithPurrNet<T>(T original, InstantiateData<T> instantiateData) where T : Object
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return instantiateData.Instantiate();
+
+            return OnPreInstantiate(prefabData, instantiateData, true);
+        }
+
+        static T InstantiateDirectlyFromPoolWithPurrNet<T>(T original, InstantiateData<T> instantiateData)
+            where T : Object
+        {
+            if (!TryGetPrefabData(original, out var prefabData))
+                return instantiateData.Instantiate();
+
+            return OnPreInstantiate(prefabData, instantiateData, false);
         }
 
         static bool OnDestroy(Object instance)
@@ -164,35 +188,37 @@ namespace PurrNet
 
         [UsedByIL]
         public static Object Instantiate(Object original)
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original);
-            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original));
+
+        public static Object InstantiateDirectlyFromPool(Object original)
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<Object>(original));
 
         [UsedByIL]
         public static Object Instantiate(Object original, Transform parent, bool instantiateInWorldSpace)
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, parent, instantiateInWorldSpace);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, parent, instantiateInWorldSpace));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, parent, instantiateInWorldSpace));
 
         public static Object InstantiateDirectly(Object original, Transform parent, bool instantiateInWorldSpace)
             => Object.Instantiate(original, parent, instantiateInWorldSpace);
 
+        public static Object InstantiateDirectlyFromPool(
+            Object original,
+            Transform parent,
+            bool instantiateInWorldSpace)
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<Object>(original, parent, instantiateInWorldSpace));
+
         [UsedByIL]
         public static Object Instantiate(Object original, Vector3 position, Quaternion rotation)
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, position, rotation);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, position, rotation));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, position, rotation));
 
         public static Object InstantiateDirectly(Object original, Vector3 position, Quaternion rotation)
             => Object.Instantiate(original, position, rotation);
+
+        public static Object InstantiateDirectlyFromPool(Object original, Vector3 position, Quaternion rotation)
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<Object>(original, position, rotation));
 
         [UsedByIL]
         public static Object Instantiate(
@@ -200,12 +226,7 @@ namespace PurrNet
             Vector3 position,
             Quaternion rotation,
             Transform parent)
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, position, rotation, parent);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, position, rotation, parent));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, position, rotation, parent));
 
         public static Object InstantiateDirectly(
             Object original,
@@ -216,100 +237,100 @@ namespace PurrNet
             return Object.Instantiate(original, position, rotation, parent);
         }
 
+        public static Object InstantiateDirectlyFromPool(
+            Object original,
+            Vector3 position,
+            Quaternion rotation,
+            Transform parent)
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<Object>(original, position, rotation, parent));
+
 #if UNITY_2023_1_OR_NEWER
         [UsedByIL]
         public static Object Instantiate(Object original, Scene scene)
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, scene);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, scene));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, scene));
 
         public static Object InstantiateDirectly(Object original, Scene scene)
             => Object.Instantiate(original, scene);
 
+        public static Object InstantiateDirectlyFromPool(Object original, Scene scene)
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<Object>(original, scene));
+
         public static T InstantiateDirectly<T>(T original, Scene scene) where T : Object
             => (T)Object.Instantiate(original, scene);
+
+        public static T InstantiateDirectlyFromPool<T>(T original, Scene scene) where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original, scene));
 #endif
 
         [UsedByIL]
         public static Object Instantiate(Object original, Transform parent)
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, parent);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<Object>(original, parent));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<Object>(original, parent));
 
         public static Object InstantiateDirectly(Object original, Transform parent)
             => Object.Instantiate(original, parent);
 
+        public static Object InstantiateDirectlyFromPool(Object original, Transform parent)
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<Object>(original, parent));
+
         [UsedByIL]
         public static T Instantiate<T>(T original) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original));
 
 #if UNITY_6000_0_OR_NEWER
         [UsedByIL]
         public static T Instantiate<T>(T original, InstantiateParameters parameters) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, parameters);
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parameters));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, parameters));
 
         [UsedByIL]
         public static T Instantiate<T>(T original, Vector3 pos, Quaternion rot, InstantiateParameters parameters) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, pos, rot, parameters);
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, pos, rot, parameters));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, pos, rot, parameters));
 
         [UsedByIL]
         public static T InstantiateDirectly<T>(T original, InstantiateParameters parameters) where T : Object
             => Object.Instantiate(original, parameters);
 
+        public static T InstantiateDirectlyFromPool<T>(T original, InstantiateParameters parameters) where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original, parameters));
+
         [UsedByIL]
         public static T InstantiateDirectly<T>(T original, Vector3 pos, Quaternion rot, InstantiateParameters parameters) where T : Object
             => Object.Instantiate(original, pos, rot, parameters);
+
+        public static T InstantiateDirectlyFromPool<T>(
+            T original,
+            Vector3 pos,
+            Quaternion rot,
+            InstantiateParameters parameters)
+            where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<T>(original, pos, rot, parameters));
 #endif
 
         public static T InstantiateDirectly<T>(T original) where T : Object
             => Object.Instantiate(original);
 
+        public static T InstantiateDirectlyFromPool<T>(T original) where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original));
+
         [UsedByIL]
         public static T Instantiate<T>(T original, Vector3 position, Quaternion rotation) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, position, rotation);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, position, rotation));
 
         public static T InstantiateDirectly<T>(T original, Vector3 position, Quaternion rotation) where T : Object
             => Object.Instantiate(original, position, rotation);
 
+        public static T InstantiateDirectlyFromPool<T>(T original, Vector3 position, Quaternion rotation)
+            where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<T>(original, position, rotation));
+
         [UsedByIL]
         public static T Instantiate<T>(T original, Vector3 position, Quaternion rotation, Scene scene) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-            {
-                var obj = Object.Instantiate(original, position, rotation);
-                var go = GetGameObject(obj);
-
-                if (go && go.scene.handle != scene.handle)
-                    SceneManager.MoveGameObjectToScene(go, scene);
-                return obj;
-            }
-
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation, scene));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, position, rotation, scene));
 
         public static T InstantiateDirectly<T>(T original, Vector3 position, Quaternion rotation, Scene scene)
             where T : Object
@@ -321,6 +342,16 @@ namespace PurrNet
             return obj;
         }
 
+        public static T InstantiateDirectlyFromPool<T>(
+            T original,
+            Vector3 position,
+            Quaternion rotation,
+            Scene scene)
+            where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<T>(original, position, rotation, scene));
+
         [UsedByIL]
         public static T Instantiate<T>(
             T original,
@@ -328,12 +359,7 @@ namespace PurrNet
             Quaternion rotation,
             Transform parent)
             where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, position, rotation, parent);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, position, rotation, parent));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, position, rotation, parent));
 
         public static T InstantiateDirectly<T>(
             T original,
@@ -343,29 +369,38 @@ namespace PurrNet
             where T : Object
             => Object.Instantiate(original, position, rotation, parent);
 
+        public static T InstantiateDirectlyFromPool<T>(
+            T original,
+            Vector3 position,
+            Quaternion rotation,
+            Transform parent)
+            where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<T>(original, position, rotation, parent));
+
         [UsedByIL]
         public static T Instantiate<T>(T original, Transform parent) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, parent);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parent));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, parent));
 
         public static T InstantiateDirectly<T>(T original, Transform parent) where T : Object
             => Object.Instantiate(original, parent);
 
+        public static T InstantiateDirectlyFromPool<T>(T original, Transform parent) where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(original, new InstantiateData<T>(original, parent));
+
         [UsedByIL]
         public static T Instantiate<T>(T original, Transform parent, bool worldPositionStays) where T : Object
-        {
-            if (!TryGetPrefabData(original, out var prefabData))
-                return Object.Instantiate(original, parent, worldPositionStays);
-
-            return OnPreInstantiate(prefabData, new InstantiateData<T>(original, parent, worldPositionStays));
-        }
+            => InstantiateWithPurrNet(original, new InstantiateData<T>(original, parent, worldPositionStays));
 
         public static T InstantiateDirectly<T>(T original, Transform parent, bool worldPositionStays) where T : Object
             => Object.Instantiate(original, parent, worldPositionStays);
+
+        public static T InstantiateDirectlyFromPool<T>(T original, Transform parent, bool worldPositionStays)
+            where T : Object
+            => InstantiateDirectlyFromPoolWithPurrNet(
+                original,
+                new InstantiateData<T>(original, parent, worldPositionStays));
 
         [UsedByIL]
         public static void Destroy(Object obj)


### PR DESCRIPTION
### Why

Currently, it's not possible to instantiate an object from PurrNet's pool without automatically spawning it over the network. This prevents us from setting custom payload data using `OnSerialize` / `OnDeserialize` to avoid the visual delay between an object's spawn and the arrival of its sync data in some cases.

#### Allows setting a custom payload, but doesn't use PurrNet's pool

```csharp
var instance = UnityProxy.InstantiateDirectly(prefab, position, rotation).GetComponent<NetworkComponent>();

instance.SetPayload(payload);
instance.Spawn(prefab, networkManager);
```

#### Uses PurrNet's pool, but doesn't allow setting a custom payload

When spawning this way, `OnSerialize` is called before `SetPayload`.

```csharp
var instance = UnityProxy.Instantiate(prefab, position, rotation).GetComponent<NetworkComponent>();

instance.SetPayload(payload);
```

### Changes in this PR

1. Adds `InstantiateDirectlyFromPool`, which instantiates an object from PurrNet's pool without automatically spawning it over the network, allowing custom payloads to be set first.
2. Cleans up `UnityProxy` a bit by removing some duplicated code.

```csharp
var instance = UnityProxy.InstantiateDirectlyFromPool(prefab, position, rotation).GetComponent<NetworkComponent>();

instance.SetPayload(payload);
instance.Spawn(prefab, networkManager);
```

### Tested Scenarios

I tested these changes in the following scenarios:

1. Creating objects with `UnityProxy.InstantiateDirectly` and calling `Spawn` manually. Tested on both the host and client. Works as expected.
2. Creating objects with `UnityProxy.InstantiateDirectlyFromPool` and calling `Spawn` manually. Tested on both the host and client. Works as expected.
3. Creating objects with `UnityProxy.Instantiate` and letting PurrNet automatically spawn the object. Tested on both the host and client. Works as expected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785326239&installation_id=129033668&pr_number=266&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F266&signature=b27dcd7ca8ae968922f503ff084a60ee8206586653c687ac3eae46508a5fc47c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made created-object notifications consistent across pooled and non-pooled instantiation flows.
  * Suppressed redundant “created” notifications when using direct-from-pool instantiation, reducing duplicate/inconsistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->