### PR TITLE
fixed serialized sync types didn't restore initial value

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
@@ -111,7 +111,6 @@ namespace PurrNet
         {
             _ownerAuth = ownerAuth;
             _useForceSend = useForceSend;
-            CacheInitialDict();
 
 #if UNITY_EDITOR
             onChanged += UpdateSerializedDict;

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
@@ -51,6 +51,8 @@ namespace PurrNet
         [SerializeField, Min(0)] private float _sendIntervalInSeconds;
         [SerializeField, Tooltip("This will send the entire state when things change. It's reliable, but more data heavy")] //We should optimize this in the future
         private bool _useForceSend;
+        [SerializeField, HideInInspector]
+        private SerializableDictionary<TKey, TValue> _initialSerializedDict = new SerializableDictionary<TKey, TValue>();
 
 
         private Dictionary<TKey, TValue> _dict = new Dictionary<TKey, TValue>();
@@ -89,6 +91,8 @@ namespace PurrNet
         public override void OnPoolReset()
         {
             onChanged = null;
+            _pendingChanges.Clear();
+            RestoreInitialDict();
             _lastSendTime = default;
             _isDirty = default;
             _wasLastDirty = default;
@@ -107,6 +111,7 @@ namespace PurrNet
         {
             _ownerAuth = ownerAuth;
             _useForceSend = useForceSend;
+            CacheInitialDict();
 
 #if UNITY_EDITOR
             onChanged += UpdateSerializedDict;
@@ -138,7 +143,18 @@ namespace PurrNet
 
         public void OnAfterDeserialize()
         {
-            _dict = _serializedDict?.ToDictionary();
+            _serializedDict.CopyTo(_dict);
+            CacheInitialDict();
+        }
+
+        private void CacheInitialDict()
+        {
+            _initialSerializedDict.FromDictionary(_dict);
+        }
+
+        private void RestoreInitialDict()
+        {
+            _initialSerializedDict.CopyTo(_dict);
         }
 
         public override void OnSpawn()
@@ -604,6 +620,13 @@ namespace PurrNet
         public Dictionary<TKey, TValue> ToDictionary()
         {
             var dict = new Dictionary<TKey, TValue>(keys.Count);
+            CopyTo(dict);
+            return dict;
+        }
+
+        public void CopyTo(Dictionary<TKey, TValue> dict)
+        {
+            dict.Clear();
 
             if (isKeySerializable && isValueSerializable)
             {
@@ -623,8 +646,6 @@ namespace PurrNet
                         dict.Add(default(TKey)!, default(TValue));
                 }
             }
-
-            return dict;
         }
 
         public void FromDictionary(Dictionary<TKey, TValue> dict)

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -78,11 +78,12 @@ namespace PurrNet
     }
 
     [Serializable]
-    public class SyncList<T> : NetworkModule, IList<T>, ITick
+    public class SyncList<T> : NetworkModule, IList<T>, ISerializationCallbackReceiver, ITick
     {
         [SerializeField] private bool _ownerAuth;
         [SerializeField, Min(0)] private float _sendIntervalInSeconds;
         [SerializeField] private List<T> _list = new List<T>();
+        [SerializeField, HideInInspector] private List<T> _initialList = new List<T>();
 
         public List<T> list => _list;
         public List<T> ToList() => _list;
@@ -121,6 +122,7 @@ namespace PurrNet
         {
             onChanged = null;
             _pendingChanges.Clear();
+            RestoreInitialList();
             _lastSendTime = default;
             _wasLastDirty = default;
             _isDirty = default;
@@ -129,12 +131,14 @@ namespace PurrNet
         public SyncList(bool ownerAuth = false)
         {
             _ownerAuth = ownerAuth;
+            CacheInitialList();
         }
 
         public SyncList(List<T> defaultValues, bool ownerAuth = false)
         {
             _list = defaultValues;
             _ownerAuth = ownerAuth;
+            CacheInitialList();
         }
 
         public T this[int idx]
@@ -170,6 +174,18 @@ namespace PurrNet
         {
             _pendingChanges.Add(change);
             _isDirty = true;
+        }
+
+        private void CacheInitialList()
+        {
+            _initialList.Clear();
+            _initialList.AddRange(_list);
+        }
+
+        private void RestoreInitialList()
+        {
+            _list.Clear();
+            _list.AddRange(_initialList);
         }
 
         public override void OnSpawn()
@@ -709,5 +725,14 @@ namespace PurrNet
         }
 
         #endregion
+
+        public void OnBeforeSerialize()
+        {
+        }
+
+        public void OnAfterDeserialize()
+        {
+            CacheInitialList();
+        }
     }
 }

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -131,7 +131,6 @@ namespace PurrNet
         public SyncList(bool ownerAuth = false)
         {
             _ownerAuth = ownerAuth;
-            CacheInitialList();
         }
 
         public SyncList(List<T> defaultValues, bool ownerAuth = false)

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -10,7 +10,7 @@ using PurrNet.Utils;
 namespace PurrNet
 {
     [Serializable]
-    public class SyncVar<T> : NetworkModule
+    public class SyncVar<T> : NetworkModule, ISerializationCallbackReceiver
     {
         private TickManager _tickManager;
 
@@ -252,7 +252,8 @@ namespace PurrNet
 
         private ulong _id;
         private bool _wasLastDirty;
-        private readonly T _initialValue;
+        [SerializeField, HideInInspector]
+        private T _initialValue;
 
         public SyncVar(T initialValue = default, float sendIntervalInSeconds = 0f, bool ownerAuth = false)
         {
@@ -379,6 +380,15 @@ namespace PurrNet
         public override string ToString()
         {
             return value.ToString();
+        }
+
+        public void OnBeforeSerialize()
+        {
+        }
+
+        public void OnAfterDeserialize()
+        {
+            _initialValue = _value;
         }
     }
 }


### PR DESCRIPTION
# Why

`SyncVar<T>._initialValue` is only set in the constructor.

So this breaks with serialized fields:

```csharp
[SerializeField] private SyncVar<float> _data;
```

If `_data` is `100` in the inspector, pooled object can respawn with `0`, because `OnPoolReset()` does:

```csharp
_value = _initialValue;
```

but `_initialValue` came from `new()`, not Unity's serialized `_value`.

Other sync types have the same issue too.

# Fix

1. Fixed `SyncVar`, `SyncList`, and `SyncDictionary` so pool reset restores inspector values. Other sync types probably need same fix too.
2. Added `_pendingChanges.Clear()` to `SyncDictionary` reset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785509825&installation_id=129033668&pr_number=267&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F267&signature=6a357bb19f0d040f6a9f21e991fce4d2ef456b9d37d0719bd153358e43362495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of networked lists, dictionaries, and variables when objects are reset or reloaded.
  * Restored their starting values more consistently after pooling and serialization, preventing stale or unexpected synced state from carrying over.
  * Updated serialization handling so restored baselines match the deserialized content.
  * Added deterministic state caching and restoration to reduce inconsistencies after lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->