### PR TITLE
Fix NetworkOwnershipToggle state on spawned replicas

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkOwnershipToggle/NetworkOwnershipToggle.cs
@@ -22,6 +22,7 @@ namespace PurrNet
 
         private bool _lastIsController;
         private bool _refreshPending;
+        private bool _forceRefreshPending;
 
         private void Awake()
         {
@@ -30,12 +31,13 @@ namespace PurrNet
 
         protected override void OnSpawned()
         {
-            RequestRefresh();
+            RequestRefresh(true);
         }
 
         protected override void OnDespawned()
         {
             _refreshPending = false;
+            _forceRefreshPending = false;
         }
 
         private void LateUpdate()
@@ -45,27 +47,31 @@ namespace PurrNet
 
             _refreshPending = false;
 
+            bool force = _forceRefreshPending;
+            _forceRefreshPending = false;
+
             if (!isSpawned)
                 return;
 
-            Refresh();
+            Refresh(force);
         }
 
-        private void RequestRefresh()
+        private void RequestRefresh(bool force = false)
         {
             if (_applyInLateUpdate)
             {
                 _refreshPending = true;
+                _forceRefreshPending |= force;
                 return;
             }
 
-            Refresh();
+            Refresh(force);
         }
 
-        private void Refresh()
+        private void Refresh(bool force = false)
         {
             bool controller = isController;
-            if (controller != _lastIsController)
+            if (force || controller != _lastIsController)
                 Setup(controller);
         }
 


### PR DESCRIPTION
## Summary

Force `NetworkOwnershipToggle` to reapply its current controller state once after spawning.

## Problem

`NetworkOwnershipToggle` initializes its targets in `Awake()` by calling `Setup(false)` and stores that value in `_lastIsController`.

However, the spawn pipeline can subsequently restore replicated `GameObject.activeSelf` states from the server before `OnSpawned()` is called.

For a non-controller replica, both `isController` and `_lastIsController` remain `false`, so the existing change guard skips `Setup(false)`. This can leave owner-only GameObjects active on a non-owner replica.

Example sequence:

1. `Awake()` calls `Setup(false)`.
2. The spawn pipeline restores a replicated active state from the server.
3. `OnSpawned()` requests a refresh.
4. `isController` is still equal to `_lastIsController`.
5. The toggle does not reapply the expected non-controller state.

## Solution

`OnSpawned()` now requests a forced refresh.

The force flag is preserved when `Apply In Late Update` is enabled, so the final controller state is still applied once in `LateUpdate`.

Regular ownership changes and reconnects continue using the existing controller-state change check.

Pending forced refreshes are cleared on despawn.

## Testing

Tested with owner-only child GameObjects on a networked player prefab.

Before this change, a non-owner replica could inherit an active GameObject state from the server and remain active because `isController` had not changed.

After this change, the current controller state is reapplied after spawning and non-owner targets are correctly disabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785696559&installation_id=129033668&pr_number=268&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F268&signature=0589197f3a2c8ef8fb1c5f0cd3ada3e9b9f5c24e9e7d8c5bafa9e478908fdf9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ownership updates so objects refresh more reliably when they are spawned.
  * Prevented missed setup updates by ensuring a refresh can run even when ownership state hasn’t changed yet.
  * Made despawn behavior cleaner by clearing any pending refreshes instead of triggering an immediate one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->