### PR TITLE
Batching rework

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -243,13 +243,22 @@ jobs:
           fi
 
           RUN=(xvfb-run -a --server-args="-screen 0 1024x768x24")
-          "${RUN[@]}" "$BIN" -batchmode -nographics \
+          touch logs/server.log
+          tail -n +1 -F logs/server.log &
+          TAIL_PID=$!
+          trap 'kill "$TAIL_PID" 2>/dev/null || true' EXIT
+          STATUS=0
+          timeout --signal=TERM --kill-after=10s 12m "${RUN[@]}" "$BIN" -batchmode -nographics \
             -role server -count ${{ needs.prep.outputs.total }} \
             -bench -benchSeconds ${{ inputs.bench_seconds }} \
             -benchObjects ${{ inputs.bench_objects }} \
             -port "$BENCH_PORT" -connectTimeout 90 \
             -results "$PWD/results/server.json" \
-            -logFile "$PWD/logs/server.log"
+            -logFile "$PWD/logs/server.log" || STATUS=$?
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::Server exited with status $STATUS"
+            exit "$STATUS"
+          fi
 
           # The Unity player writes everything to -logFile, so surface the bind result here.
           if grep -q "Bind exception" logs/server.log 2>/dev/null; then
@@ -337,13 +346,22 @@ jobs:
           echo "Server resolved to $SERVER_IP"
 
           RUN=(xvfb-run -a --server-args="-screen 0 1024x768x24")
-          "${RUN[@]}" "$BIN" -batchmode -nographics \
+          touch logs/client-${{ matrix.idx }}.log
+          tail -n +1 -F logs/client-${{ matrix.idx }}.log &
+          TAIL_PID=$!
+          trap 'kill "$TAIL_PID" 2>/dev/null || true' EXIT
+          STATUS=0
+          timeout --signal=TERM --kill-after=10s 12m "${RUN[@]}" "$BIN" -batchmode -nographics \
             -role client -bench -benchSeconds ${{ inputs.bench_seconds }} \
             -benchObjects ${{ inputs.bench_objects }} \
             -benchPingRate ${{ inputs.ping_rate }} \
             -serverHost "$SERVER_IP" -port "$BENCH_PORT" -connectTimeout 90 \
             -results "$PWD/results/client-${{ matrix.idx }}.json" \
-            -logFile "$PWD/logs/client-${{ matrix.idx }}.log"
+            -logFile "$PWD/logs/client-${{ matrix.idx }}.log" || STATUS=$?
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::Client ${{ matrix.idx }} exited with status $STATUS"
+            exit "$STATUS"
+          fi
 
       - name: Tail client log on failure
         if: failure()
@@ -411,23 +429,67 @@ jobs:
             exit 1
           fi
 
-          RUN=(xvfb-run -a --server-args="-screen 0 1024x768x24")
           PIDS=()
+          declare -A PROC_BY_PID=()
           for p in $(seq 1 ${{ inputs.procs_per_loadgen }}); do
-            "${RUN[@]}" "$BIN" -batchmode -nographics \
+            # Concurrent xvfb-run -a calls can select the same display before either
+            # lock file exists. Give every process a deterministic private display.
+            DISPLAY_NUM=$((100 + p))
+            timeout --signal=TERM --kill-after=10s 12m \
+              xvfb-run --server-num="$DISPLAY_NUM" \
+              --error-file="$PWD/logs/xvfb-${{ matrix.idx }}-$p.log" \
+              --server-args="-screen 0 1024x768x24" \
+              "$BIN" -batchmode -nographics \
               -role client -loadgen -bench -benchSeconds ${{ inputs.bench_seconds }} \
               -benchObjects ${{ inputs.bench_objects }} -benchPingRate 0 \
               -serverHost "$SERVER_IP" -port "$BENCH_PORT" -connectTimeout 90 \
               -results "$PWD/results/loadgen-${{ matrix.idx }}-$p.json" \
               -logFile "$PWD/logs/loadgen-${{ matrix.idx }}-$p.log" &
-            PIDS+=("$!")
+            PID=$!
+            PIDS+=("$PID")
+            PROC_BY_PID["$PID"]=$p
           done
-          FAIL=0
-          for pid in "${PIDS[@]}"; do
-            wait "$pid" || FAIL=1
+
+          terminate_remaining() {
+            for pid in "${!PROC_BY_PID[@]}"; do
+              kill "$pid" 2>/dev/null || true
+            done
+            wait 2>/dev/null || true
+          }
+          trap terminate_remaining EXIT
+
+          REMAINING=${#PIDS[@]}
+          while [ "$REMAINING" -gt 0 ]; do
+            STATUS=0
+            FINISHED_PID=""
+            wait -n -p FINISHED_PID "${!PROC_BY_PID[@]}" || STATUS=$?
+            PROC=${PROC_BY_PID[$FINISHED_PID]}
+            unset "PROC_BY_PID[$FINISHED_PID]"
+            REMAINING=$((REMAINING - 1))
+
+            if [ "$STATUS" -ne 0 ]; then
+              echo "::error::Loadgen process $PROC exited with status $STATUS"
+              tail -n 120 "logs/loadgen-${{ matrix.idx }}-$PROC.log" || true
+              tail -n 40 "logs/xvfb-${{ matrix.idx }}-$PROC.log" || true
+              exit "$STATUS"
+            fi
           done
-          # Loadgen exit status is informational; the measured peers decide pass/fail.
-          exit 0
+          trap - EXIT
+
+      - name: Tail loadgen logs on failure
+        if: failure()
+        run: tail -n 80 logs/*.log || true
+
+      - name: Upload loadgen diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-log-loadgen-${{ inputs.tag }}-${{ matrix.idx }}
+          path: |
+            results/
+            logs/
+          if-no-files-found: warn
+          retention-days: 14
 
   aggregate:
     name: Aggregate results

--- a/Assets/PlayModeTests/Scripts/Bootstrap.cs
+++ b/Assets/PlayModeTests/Scripts/Bootstrap.cs
@@ -359,7 +359,17 @@ public class Bootstrap : Scenario
         if (!ctx.isServer)
             return ScenarioResult.Ok();
 
-        await UniTaskUtils.WaitWithTimeout(AllConnected, _connectionTimeout, ctx.cancellationToken);
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(AllConnected, _connectionTimeout, ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            Debug.LogError(
+                $"[Bootstrap] connection timeout: players={_networkManager.playerCount}/{_expectedConnections}, " +
+                $"role={_role}, timeout={_connectionTimeout:F0}s");
+            throw;
+        }
         return ScenarioResult.Ok();
     }
 
@@ -403,8 +413,21 @@ public class Bootstrap : Scenario
             // clients don't exist on the server yet, so there's no one to coordinate with.
             if (_scenarios.Length > 0)
             {
-                if (await RunOne(0, ctx))
+                bool bootstrapFailed = await RunOne(0, ctx);
+                if (bootstrapFailed)
+                {
                     anyFailed = true;
+
+                    // No later scenario can make progress without the complete peer set.
+                    // Tell already-connected clients to leave their start wait, then let
+                    // every process write its failure result and exit.
+                    if (ctx.isServer && _networkManager.isServer)
+                    {
+                        ScenarioSequencer.IssueSequenceComplete();
+                        await ScenarioSequencer.WaitForEndOfRunHandshake(ctx);
+                    }
+                    return;
+                }
             }
 
             if (ctx.isServer)
@@ -443,7 +466,7 @@ public class Bootstrap : Scenario
 
                     // Defensive: server signalled the run is over (or crashed). Stop
                     // running scenarios the server isn't tracking.
-                    if (ScenarioSequencer.SequenceComplete)
+                    if (ScenarioSequencer.SequenceComplete || !_networkManager.isClient)
                         break;
 
                     if (await RunOne(i, ctx))
@@ -460,7 +483,7 @@ public class Bootstrap : Scenario
                 // Wait for the server's sequence-complete broadcast, then ack so
                 // the server can exit its handshake wait cleanly. This is best-effort:
                 // a terminal scenario may intentionally stop the original server.
-                if (await TryWaitForSequenceComplete(ctx))
+                if (_networkManager.isClient && await TryWaitForSequenceComplete(ctx))
                 {
                     ScenarioSequencer.AckEndOfRun(ctx);
                     // Give the ack a couple frames to flush through transport before

--- a/Assets/PlayModeTests/Scripts/ScenarioSequencer.cs
+++ b/Assets/PlayModeTests/Scripts/ScenarioSequencer.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Cysharp.Threading.Tasks;
 using PurrNet;
+using UnityEngine;
 
 public static class ScenarioSequencer
 {
-    private const float SCENARIO_TIMEOUT_SECONDS = 24f * 60f * 60f;
+    private const float SCENARIO_TIMEOUT_SECONDS = 5f * 60f;
     private const float END_OF_RUN_HANDSHAKE_TIMEOUT_SECONDS = 10f;
 
     private static readonly Dictionary<int, HashSet<PlayerID>> _acksByIndex = new();
@@ -23,10 +25,20 @@ public static class ScenarioSequencer
 
     public static async UniTask WaitForStart(ScenarioContext ctx, int index)
     {
-        await UniTaskUtils.WaitWithTimeout(
-            () => _latestStartedIndex >= index || _sequenceComplete,
-            SCENARIO_TIMEOUT_SECONDS,
-            ctx.cancellationToken);
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => _latestStartedIndex >= index || _sequenceComplete || !ctx.networkManager.isClient,
+                SCENARIO_TIMEOUT_SECONDS,
+                ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            Debug.LogError(
+                $"[ScenarioSequencer] start timeout: waitingFor={index}, latest={_latestStartedIndex}, " +
+                $"sequenceComplete={_sequenceComplete}");
+            throw;
+        }
     }
 
     public static async UniTask WaitForAllAcks(ScenarioContext ctx, int index)
@@ -34,12 +46,41 @@ public static class ScenarioSequencer
         var localId = ctx.networkManager.localPlayer;
         bool isHost = ctx.role == NetworkRole.Host;
 
-        await UniTaskUtils.WaitWithTimeout(
-            () => AllConnectedClientsAcked(ctx, index, localId, isHost),
-            SCENARIO_TIMEOUT_SECONDS,
-            ctx.cancellationToken);
+        try
+        {
+            await UniTaskUtils.WaitWithTimeout(
+                () => AllConnectedClientsAcked(ctx, index, localId, isHost),
+                SCENARIO_TIMEOUT_SECONDS,
+                ctx.cancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            Debug.LogError(
+                $"[ScenarioSequencer] ack timeout: scenario={index}, " +
+                $"missing={DescribeMissingAcks(ctx, index, localId, isHost)}");
+            throw;
+        }
 
         _acksByIndex.Remove(index);
+    }
+
+    private static string DescribeMissingAcks(ScenarioContext ctx, int index, PlayerID localId, bool isHost)
+    {
+        _acksByIndex.TryGetValue(index, out var acks);
+        var connected = ctx.networkManager.players;
+        var missing = new StringBuilder();
+        for (int i = 0; i < connected.Count; i++)
+        {
+            var player = connected[i];
+            if ((isHost && player == localId) || (acks != null && acks.Contains(player)))
+                continue;
+
+            if (missing.Length > 0)
+                missing.Append(',');
+            missing.Append(player);
+        }
+
+        return missing.Length == 0 ? "none (connected set changed while timing out)" : missing.ToString();
     }
 
     private static bool AllConnectedClientsAcked(ScenarioContext ctx, int index, PlayerID localId, bool isHost)

--- a/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
+++ b/Assets/PurrNet/Runtime/BitPacker/BitPacker.cs
@@ -231,17 +231,21 @@ namespace PurrNet.Packing
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void EnsureBitsExist(int positionInBits, int bits)
         {
             int targetPos = positionInBits + bits;
-            var bufferBitSize = _buffer.Length * 8;
+            int bufferBitSize = _buffer.Length * 8;
 
             if (targetPos > bufferBitSize)
             {
                 if (_isReading)
                     throw new IndexOutOfRangeException("Not enough bits in the buffer. | " + targetPos + " > " +
                                                        bufferBitSize);
-                Array.Resize(ref _buffer, _buffer.Length * 2);
+
+                int requiredBytes = ((targetPos + 7) >> 3) + 8;
+                int newSize = Math.Max(_buffer.Length * 2, requiredBytes);
+                Array.Resize(ref _buffer, newSize);
             }
         }
 
@@ -302,45 +306,168 @@ namespace PurrNet.Packing
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteBitDataWithoutConsumingIt(BitData data)
         {
-            int toRead = (int)data.bitLength.value;
-            if (toRead == 0) return;
-
-            var other = data.packer;
-            var beforeBitPosition = other._positionInBits;
-
-            other._positionInBits = data.bitOrigin;
-            EnsureBitsExist(toRead);
-
-            int chunks = toRead / 64;
-            byte excess = (byte)(toRead % 64);
-
-            for (int i = 0; i < chunks; i++)
-                WriteBitsWithoutChecks(other.ReadBits(64), 64);
-
-            if (excess != 0)
-                WriteBitsWithoutChecks(other.ReadBits(excess), excess);
-
-            other.SetBitPosition(beforeBitPosition);
+            CopyBitsWithoutConsuming(data.packer, (int)data.bitOrigin.value, (int)data.bitLength.value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteBitsWithoutConsumingIt(BitPacker packer, int bits)
         {
+            CopyBitsWithoutConsuming(packer, 0, bits);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void WriteBitsWithoutConsumingItUnchecked(BitPacker packer, int bits)
+        {
+            if (bits == 0)
+                return;
+
             EnsureBitsExist(bits);
+            CopyBitsFromValidatedSource(packer, 0, bits);
+        }
 
-            var beforeBitPosition = packer._positionInBits;
-            packer.SetBitPosition(0);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void CopyBitsWithoutConsuming(BitPacker other, int bitOrigin, int bits)
+        {
+            if (bits == 0)
+                return;
 
-            int chunks = bits / 64;
-            byte excess = (byte)(bits % 64);
+            EnsureBitsExist(bits);
+            other.EnsureBitsExist(bitOrigin, bits);
+            CopyBitsFromValidatedSource(other, bitOrigin, bits);
+        }
 
-            for (int i = 0; i < chunks; i++)
-                WriteBitsWithoutChecks(packer.ReadBits(64), 64);
-            if (excess != 0)
-                WriteBitsWithoutChecks(packer.ReadBits(excess), excess);
+        private unsafe void CopyBitsFromValidatedSource(BitPacker other, int bitOrigin, int bits)
+        {
+            if (((_positionInBits | bitOrigin) & 7) == 0)
+            {
+                int fullBytes = bits >> 3;
+                if (fullBytes > 0)
+                {
+                    other._buffer.AsSpan(bitOrigin >> 3, fullBytes)
+                        .CopyTo(_buffer.AsSpan(_positionInBits >> 3, fullBytes));
+                    _positionInBits += fullBytes << 3;
+                }
 
-            packer.SetBitPosition(beforeBitPosition);
+                byte remainingBits = (byte)(bits & 7);
+                if (remainingBits != 0)
+                    WriteBitsWithoutChecks(other._buffer[(bitOrigin >> 3) + fullBytes], remainingBits);
+                return;
+            }
+
+            bool hasIndependentByteAlignedSource = (bitOrigin & 7) == 0 && !ReferenceEquals(_buffer, other._buffer);
+            if (hasIndependentByteAlignedSource)
+            {
+                if (bits >= 80)
+                {
+                    CopyByteAlignedSourceToUnalignedDestination(other, bitOrigin >> 3, bits);
+                    return;
+                }
+
+                int sourcePosition = other._positionInBits;
+                other._positionInBits = bitOrigin;
+                int chunks = bits >> 6;
+                byte excess = (byte)(bits & 63);
+                for (int i = 0; i < chunks; i++)
+                    WriteBitsWithoutChecks(other.ReadBitsWithoutChecks(64), 64);
+                if (excess != 0)
+                    WriteBitsWithoutChecks(other.ReadBitsWithoutChecks(excess), excess);
+                other._positionInBits = sourcePosition;
+                return;
+            }
+
+            int beforeBitPosition = other._positionInBits;
+            other._positionInBits = bitOrigin;
+
+            try
+            {
+                int chunks = bits >> 6;
+                byte excess = (byte)(bits & 63);
+
+                for (int i = 0; i < chunks; i++)
+                    WriteBitsWithoutChecks(other.ReadBitsWithoutChecks(64), 64);
+                if (excess != 0)
+                    WriteBitsWithoutChecks(other.ReadBitsWithoutChecks(excess), excess);
+            }
+            finally
+            {
+                other._positionInBits = beforeBitPosition;
+            }
+        }
+
+        private unsafe void CopyByteAlignedSourceToUnalignedDestination(BitPacker other, int sourceByteOrigin,
+            int bits)
+        {
+            int chunks = bits >> 6;
+            byte excess = (byte)(bits & 63);
+            int destinationBitOffset = _positionInBits & 7;
+            ulong preservedLowBits = (1UL << destinationBitOffset) - 1;
+            byte overflowMask = (byte)((1 << destinationBitOffset) - 1);
+
+            fixed (byte* source = &other._buffer[sourceByteOrigin])
+            fixed (byte* destination = &_buffer[_positionInBits >> 3])
+            {
+                for (int i = 0; i < chunks; i++)
+                {
+                    byte* destinationChunk = destination + (i << 3);
+                    ulong value = *(ulong*)(source + (i << 3));
+                    ulong existing = *(ulong*)destinationChunk;
+#if PURR_ENDIAN
+                    if (!BitConverter.IsLittleEndian)
+                    {
+                        value = BinaryPrimitives.ReverseEndianness(value);
+                        existing = BinaryPrimitives.ReverseEndianness(existing);
+                    }
+#endif
+                    ulong result = (existing & preservedLowBits) | (value << destinationBitOffset);
+#if PURR_ENDIAN
+                    if (!BitConverter.IsLittleEndian)
+                        result = BinaryPrimitives.ReverseEndianness(result);
+#endif
+                    *(ulong*)destinationChunk = result;
+
+                    byte highData = (byte)(value >> (64 - destinationBitOffset));
+                    byte* overflowByte = destinationChunk + 8;
+                    *overflowByte = (byte)((*overflowByte & ~overflowMask) | (highData & overflowMask));
+                }
+
+                if (excess != 0)
+                {
+                    ulong value = 0;
+                    byte* remainingSource = source + (chunks << 3);
+                    int bytesToRead = (excess + 7) >> 3;
+                    for (int i = 0; i < bytesToRead; i++)
+                        value |= (ulong)remainingSource[i] << (i << 3);
+
+                    byte* destinationChunk = destination + (chunks << 3);
+                    ulong dataMask = (1UL << excess) - 1;
+                    ulong writeMask = dataMask << destinationBitOffset;
+                    ulong existing = *(ulong*)destinationChunk;
+#if PURR_ENDIAN
+                    if (!BitConverter.IsLittleEndian)
+                        existing = BinaryPrimitives.ReverseEndianness(existing);
+#endif
+                    ulong result = (existing & ~writeMask) | ((value & dataMask) << destinationBitOffset);
+#if PURR_ENDIAN
+                    if (!BitConverter.IsLittleEndian)
+                        result = BinaryPrimitives.ReverseEndianness(result);
+#endif
+                    *(ulong*)destinationChunk = result;
+
+                    int overflow = excess + destinationBitOffset - 64;
+                    if (overflow > 0)
+                    {
+                        byte highMask = (byte)((1 << overflow) - 1);
+                        byte highData = (byte)(value >> (64 - destinationBitOffset));
+                        byte* overflowByte = destinationChunk + 8;
+                        *overflowByte = (byte)((*overflowByte & ~highMask) | (highData & highMask));
+                    }
+                }
+            }
+
+            _positionInBits += bits;
         }
 
         public void WriteBits(BitPacker packer, int bits)

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/BatchKey.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/BatchKey.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using PurrNet.Transports;
 
 namespace PurrNet.Modules
@@ -20,7 +22,57 @@ namespace PurrNet.Modules
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(playerId, (int)channel);
+            unchecked
+            {
+                return (playerId.GetHashCode() * 397) ^ (int)channel;
+            }
+        }
+    }
+
+    internal sealed class BatchIndexMap : IDisposable
+    {
+        private const int ChannelCount = (int)Channel.Unreliable + 1;
+        private readonly Dictionary<ulong, int>[] _channels;
+
+        public BatchIndexMap(int initialCapacity)
+        {
+            _channels = new Dictionary<ulong, int>[ChannelCount];
+            for (int i = 0; i < _channels.Length; i++)
+                _channels[i] = new Dictionary<ulong, int>(initialCapacity);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryGetValue(ulong playerId, Channel channel, out int value)
+        {
+            return _channels[(int)channel].TryGetValue(playerId, out value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Set(ulong playerId, Channel channel, int value)
+        {
+            int channelIndex = (int)channel;
+            if ((uint)channelIndex >= (uint)_channels.Length)
+                throw new ArgumentOutOfRangeException(nameof(channel), channel, null);
+            _channels[channelIndex][playerId] = value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Remove(ulong playerId, Channel channel)
+        {
+            int channelIndex = (int)channel;
+            return (uint)channelIndex < (uint)_channels.Length &&
+                   _channels[channelIndex].Remove(playerId);
+        }
+
+        public void Clear()
+        {
+            for (int i = 0; i < _channels.Length; i++)
+                _channels[i].Clear();
+        }
+
+        public void Dispose()
+        {
+            Clear();
         }
     }
 }

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RPCBatch.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RPCBatch.cs
@@ -100,8 +100,6 @@ namespace PurrNet.Modules
             _playersManager = playersManager;
             _onRPCReceived = callback;
             _batchIndexMap = new BatchIndexMap(128);
-            _entryCacheA.data = BitPackerPool.Get();
-            _entryCacheB.data = BitPackerPool.Get();
             _playersManager.Subscribe<RPCBatchPacket>(OnBatchReceived);
         }
 
@@ -111,8 +109,6 @@ namespace PurrNet.Modules
             _backend = backend;
             _onRPCReceived = callback;
             _batchIndexMap = new BatchIndexMap(128);
-            _entryCacheA.data = BitPackerPool.Get();
-            _entryCacheB.data = BitPackerPool.Get();
             _backend.Subscribe(OnBatchReceived);
         }
 #endif
@@ -129,8 +125,8 @@ namespace PurrNet.Modules
 #endif
 
             Clear();
-            _entryCacheA.data.Dispose();
-            _entryCacheB.data.Dispose();
+            _entryCacheA.data?.Dispose();
+            _entryCacheB.data?.Dispose();
             _batchIndexMap.Dispose();
         }
 
@@ -259,6 +255,13 @@ namespace PurrNet.Modules
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureEntryCache()
+        {
+            _entryCacheA.data ??= BitPackerPool.Get();
+            _entryCacheB.data ??= BitPackerPool.Get();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ulong NextStateVersion()
         {
             ulong version = ++_nextStateVersion;
@@ -282,7 +285,7 @@ namespace PurrNet.Modules
             if (!cache.isValid)
                 return false;
 
-            if (cache.previousStateVersion == previousStateVersion)
+            if (previousStateVersion != 0 && cache.previousStateVersion == previousStateVersion)
                 return true;
 
             return cache.previousDataLen.value == previousDataLen.value &&
@@ -396,18 +399,19 @@ namespace PurrNet.Modules
         {
             ValidateChannel(channel);
             _queueMultiMarker.Begin();
-            ulong stateVersion = NextStateVersion();
 
             if (targets.Count < 3)
             {
                 for (var i = targets.Count - 1; i >= 0; i--)
-                    QueueDirect(targets[i], header, content, channel, stateVersion);
+                    QueueDirect(targets[i], header, content, channel);
 
                 _queueMultiMarker.End();
                 return;
             }
 
+            EnsureEntryCache();
             ResetEntryCache();
+            ulong stateVersion = NextStateVersion();
             var contentLen = content.bitLength;
 
             for (var i = targets.Count - 1; i >= 0; i--)
@@ -446,7 +450,6 @@ namespace PurrNet.Modules
         {
             ValidateChannel(channel);
             _queueMultiMarker.Begin();
-            ulong stateVersion = NextStateVersion();
 
             bool hasFilter = filter.hasSkipA || filter.hasSkipB;
 
@@ -456,14 +459,16 @@ namespace PurrNet.Modules
                 {
                     var target = targets[i];
                     if (!hasFilter || !filter.ShouldSkip(target))
-                        QueueDirect(target, header, content, channel, stateVersion);
+                        QueueDirect(target, header, content, channel);
                 }
 
                 _queueMultiMarker.End();
                 return;
             }
 
+            EnsureEntryCache();
             ResetEntryCache();
+            ulong stateVersion = NextStateVersion();
             var contentLen = content.bitLength;
 
             for (var i = targets.Count - 1; i >= 0; i--)
@@ -477,7 +482,7 @@ namespace PurrNet.Modules
         }
 
         private unsafe void QueueDirect(PlayerID target, in UnionRPCHeader header, in BitData content,
-            Channel channel, ulong stateVersion)
+            Channel channel)
         {
             var batchIdx = GetBatchIndex(target, channel);
             ref var batch = ref _batches[batchIdx];
@@ -510,7 +515,7 @@ namespace PurrNet.Modules
             ++batch.batchCount;
             batch.lastHeader = header;
             batch.lastDataLen = contentLen;
-            batch.stateVersion = stateVersion;
+            batch.stateVersion = 0;
 
             if (contentLen.value > 0)
                 batch.batchedData.WriteBitDataWithoutConsumingIt(content);
@@ -521,7 +526,7 @@ namespace PurrNet.Modules
             ValidateChannel(channel);
             _queueSingleMarker.Begin();
 
-            QueueDirect(target, header, content, channel, NextStateVersion());
+            QueueDirect(target, header, content, channel);
             _queueSingleMarker.End();
         }
 

--- a/Assets/PurrNet/Runtime/CoreModules/RPCs/RPCBatch.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/RPCs/RPCBatch.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using PurrNet.Packing;
 using PurrNet.Pooling;
 using PurrNet.Transports;
-using Unity.Collections;
 using Unity.Profiling;
 
 namespace PurrNet.Modules
@@ -22,10 +21,31 @@ namespace PurrNet.Modules
         public BatchKey key;
         public UnionRPCHeader lastHeader;
         public Size lastDataLen;
+        public ulong stateVersion;
         public int batchCount;
         public int cachedMTU;
         public BitPacker batchedData;
     }
+
+    internal struct CachedRPCEntry
+    {
+        public UnionRPCHeader previousHeader;
+        public Size previousDataLen;
+        public ulong previousStateVersion;
+        public int bitLength;
+        public BitPacker data;
+        public bool isValid;
+    }
+
+#if UNITY_INCLUDE_TESTS
+    internal interface IRPCBatchBackend
+    {
+        int GetMTU(PlayerID player, Channel channel, bool asServer);
+        void Send(PlayerID player, RPCBatchPacket data, Channel channel);
+        void Subscribe(PlayerBroadcastDelegate<RPCBatchPacket> callback);
+        void Unsubscribe(PlayerBroadcastDelegate<RPCBatchPacket> callback);
+    }
+#endif
 
     public readonly struct ObserverFilter
     {
@@ -62,9 +82,15 @@ namespace PurrNet.Modules
         static readonly ProfilerMarker _batchReceivedMarker = new ProfilerMarker($"RPCBatch<{nameof(UnionRPCHeader)}>.OnBatchReceived");
 
         private readonly PlayersManager _playersManager;
+#if UNITY_INCLUDE_TESTS
+        private readonly IRPCBatchBackend _backend;
+#endif
         private PendingBatchedData[] _batches = new PendingBatchedData[128];
-        private NativeHashMap<BatchKey, int> _batchIndexMap;
+        private readonly BatchIndexMap _batchIndexMap;
         private int _batchCount = 0;
+        private ulong _nextStateVersion;
+        private CachedRPCEntry _entryCacheA;
+        private CachedRPCEntry _entryCacheB;
 
         public delegate void RPCReceivedDelegate(PlayerID sender, UnionRPCHeader header, BitData content, bool asServer);
         private readonly RPCReceivedDelegate _onRPCReceived;
@@ -73,13 +99,38 @@ namespace PurrNet.Modules
         {
             _playersManager = playersManager;
             _onRPCReceived = callback;
+            _batchIndexMap = new BatchIndexMap(128);
+            _entryCacheA.data = BitPackerPool.Get();
+            _entryCacheB.data = BitPackerPool.Get();
             _playersManager.Subscribe<RPCBatchPacket>(OnBatchReceived);
-            _batchIndexMap = new NativeHashMap<BatchKey, int>(128, Allocator.Persistent);
         }
+
+#if UNITY_INCLUDE_TESTS
+        internal RPCBatch(IRPCBatchBackend backend, RPCReceivedDelegate callback)
+        {
+            _backend = backend;
+            _onRPCReceived = callback;
+            _batchIndexMap = new BatchIndexMap(128);
+            _entryCacheA.data = BitPackerPool.Get();
+            _entryCacheB.data = BitPackerPool.Get();
+            _backend.Subscribe(OnBatchReceived);
+        }
+#endif
 
         public void Dispose()
         {
+#if UNITY_INCLUDE_TESTS
+            if (_playersManager != null)
+                _playersManager.Unsubscribe<RPCBatchPacket>(OnBatchReceived);
+            else
+                _backend.Unsubscribe(OnBatchReceived);
+#else
             _playersManager.Unsubscribe<RPCBatchPacket>(OnBatchReceived);
+#endif
+
+            Clear();
+            _entryCacheA.data.Dispose();
+            _entryCacheB.data.Dispose();
             _batchIndexMap.Dispose();
         }
 
@@ -96,12 +147,13 @@ namespace PurrNet.Modules
                         data = new BitData(batch.batchedData)
                     };
 
-                    _playersManager.Send(batch.key.playerId, data, batch.key.channel);
+                    Send(batch.key.playerId, data, batch.key.channel);
                     batch.batchedData.Dispose();
                 }
 
                 _batchCount = 0;
                 _batchIndexMap.Clear();
+                _nextStateVersion = 0;
             }
         }
 
@@ -119,7 +171,7 @@ namespace PurrNet.Modules
                     {
                         SendBatch(ref batch);
                         batch.batchedData.Dispose();
-                        _batchIndexMap.Remove(batch.key);
+                        _batchIndexMap.Remove(batch.key.playerId.id.value, batch.key.channel);
                     }
                     else
                     {
@@ -127,7 +179,7 @@ namespace PurrNet.Modules
                         if (writeIdx != i)
                         {
                             _batches[writeIdx] = _batches[i];
-                            _batchIndexMap[batch.key] = writeIdx;
+                            _batchIndexMap.Set(batch.key.playerId.id.value, batch.key.channel, writeIdx);
                         }
                         writeIdx++;
                     }
@@ -145,15 +197,40 @@ namespace PurrNet.Modules
                 data = new BitData(batch.batchedData)
             };
 
-            _playersManager.Send(batch.key.playerId, data, batch.key.channel);
+            Send(batch.key.playerId, data, batch.key.channel);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int GetBatchIndex(BatchKey key)
+        private void Send(PlayerID player, RPCBatchPacket data, Channel channel)
         {
-            if (_batchIndexMap.TryGetValue(key, out int idx))
+#if UNITY_INCLUDE_TESTS
+            if (_playersManager != null)
+                _playersManager.Send(player, data, channel);
+            else
+                _backend.Send(player, data, channel);
+#else
+            _playersManager.Send(player, data, channel);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetMTU(PlayerID player, Channel channel, bool asServer)
+        {
+#if UNITY_INCLUDE_TESTS
+            return _playersManager != null
+                ? _playersManager.GetMTU(player, channel, asServer)
+                : _backend.GetMTU(player, channel, asServer);
+#else
+            return _playersManager.GetMTU(player, channel, asServer);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetBatchIndex(PlayerID playerId, Channel channel)
+        {
+            if (_batchIndexMap.TryGetValue(playerId.id.value, channel, out int idx))
                 return idx;
-            return CreateBatch(key);
+            return CreateBatch(new BatchKey { playerId = playerId, channel = channel });
         }
 
         private int CreateBatch(BatchKey key)
@@ -167,11 +244,124 @@ namespace PurrNet.Modules
             {
                 key = key,
                 batchedData = BitPackerPool.Get(),
-                cachedMTU = _playersManager.GetMTU(key.playerId, key.channel, key.playerId != PlayerID.Server)
+                cachedMTU = GetMTU(key.playerId, key.channel, key.playerId != PlayerID.Server)
             };
-            _batchIndexMap[key] = c;
+            _batchIndexMap.Set(key.playerId.id.value, key.channel, c);
             _batchCount++;
             return c;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ResetEntryCache()
+        {
+            _entryCacheA.isValid = false;
+            _entryCacheB.isValid = false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ulong NextStateVersion()
+        {
+            ulong version = ++_nextStateVersion;
+            if (version != 0)
+                return version;
+
+            // Version zero is reserved for a new/default batch state. If the counter wraps,
+            // give every live batch a unique version before issuing the next shared version.
+            // This prevents a partially filtered recipient from aliasing a state last used
+            // 2^64 queue operations ago.
+            for (int i = 0; i < _batchCount; i++)
+                _batches[i].stateVersion = ++_nextStateVersion;
+
+            return ++_nextStateVersion;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsCacheHit(in CachedRPCEntry cache, ulong previousStateVersion,
+            in UnionRPCHeader previousHeader, Size previousDataLen)
+        {
+            if (!cache.isValid)
+                return false;
+
+            if (cache.previousStateVersion == previousStateVersion)
+                return true;
+
+            return cache.previousDataLen.value == previousDataLen.value &&
+                   cache.previousHeader.Equals(previousHeader);
+        }
+
+        private static unsafe void BuildCachedEntry(ref CachedRPCEntry cache, in UnionRPCHeader previousHeader,
+            Size previousDataLen, ulong previousStateVersion, in UnionRPCHeader header, in BitData content,
+            Size contentLen)
+        {
+            var packer = cache.data;
+            packer.ResetPositionAndMode(false);
+            NativeDeltaPacker<UnionRPCHeader>.WriteFunc(packer, previousHeader, header);
+            DeltaPackInteger.WriteIndex(packer, previousDataLen, contentLen);
+
+            if (contentLen.value > 0)
+                packer.WriteBitDataWithoutConsumingIt(content);
+
+            cache.previousHeader = previousHeader;
+            cache.previousDataLen = previousDataLen;
+            cache.previousStateVersion = previousStateVersion;
+            cache.bitLength = packer.positionInBits;
+            cache.isValid = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void GetCachedEntry(in UnionRPCHeader previousHeader, Size previousDataLen,
+            ulong previousStateVersion, in UnionRPCHeader header, in BitData content, Size contentLen,
+            out BitPacker data, out int bitLength)
+        {
+            if (IsCacheHit(_entryCacheA, previousStateVersion, previousHeader, previousDataLen))
+            {
+                data = _entryCacheA.data;
+                bitLength = _entryCacheA.bitLength;
+                return;
+            }
+
+            if (IsCacheHit(_entryCacheB, previousStateVersion, previousHeader, previousDataLen))
+            {
+                data = _entryCacheB.data;
+                bitLength = _entryCacheB.bitLength;
+                return;
+            }
+
+            ref var cache = ref (_entryCacheA.isValid ? ref _entryCacheB : ref _entryCacheA);
+            BuildCachedEntry(ref cache, previousHeader, previousDataLen, previousStateVersion, header, content,
+                contentLen);
+            data = cache.data;
+            bitLength = cache.bitLength;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void QueueCached(PlayerID target, in UnionRPCHeader header, in BitData content, Size contentLen,
+            Channel channel, ulong stateVersion)
+        {
+            var batchIdx = GetBatchIndex(target, channel);
+            ref var batch = ref _batches[batchIdx];
+
+            GetCachedEntry(batch.lastHeader, batch.lastDataLen, batch.stateVersion, header, content, contentLen,
+                out var entryData, out int entryBitLength);
+
+            if (batch.batchCount > 0)
+            {
+                int bytesAfterEntry = (batch.batchedData.positionInBits + entryBitLength + 7) >> 3;
+                if (bytesAfterEntry + 10 >= batch.cachedMTU)
+                {
+                    SendBatch(ref batch);
+                    batch.batchCount = 0;
+                    batch.batchedData.ResetPositionAndMode(false);
+                    GetCachedEntry(default, default, 0, header, content, contentLen, out entryData,
+                        out entryBitLength);
+                }
+            }
+
+            batch.batchedData.WriteBitsWithoutConsumingItUnchecked(entryData, entryBitLength);
+            ++batch.batchCount;
+            batch.lastHeader = header;
+            batch.lastDataLen = contentLen;
+            batch.stateVersion = stateVersion;
         }
 
         private unsafe void OnBatchReceived(PlayerID player, RPCBatchPacket data, bool asServer)
@@ -204,107 +394,92 @@ namespace PurrNet.Modules
 
         public unsafe void Queue(DisposableList<PlayerID> targets, UnionRPCHeader header, BitData content, Channel channel)
         {
+            ValidateChannel(channel);
             _queueMultiMarker.Begin();
+            ulong stateVersion = NextStateVersion();
 
+            if (targets.Count < 3)
+            {
+                for (var i = targets.Count - 1; i >= 0; i--)
+                    QueueDirect(targets[i], header, content, channel, stateVersion);
+
+                _queueMultiMarker.End();
+                return;
+            }
+
+            ResetEntryCache();
             var contentLen = content.bitLength;
-            int contentByteLen = content.byteLength;
-            bool hasContent = contentLen.value > 0;
 
             for (var i = targets.Count - 1; i >= 0; i--)
-            {
-                var batchIdx = GetBatchIndex(new BatchKey { playerId = targets[i], channel = channel });
-                ref var batch = ref _batches[batchIdx];
-
-                int before = batch.batchedData.positionInBits;
-
-                NativeDeltaPacker<UnionRPCHeader>.WriteFunc(batch.batchedData, batch.lastHeader, header);
-                DeltaPackInteger.WriteIndex(batch.batchedData, batch.lastDataLen, contentLen);
-
-                // do some MTU checks past 1 batch
-                if (batch.batchCount > 0)
-                {
-                    int bytesAfterHeaderLen = batch.batchedData.positionInBytes + contentByteLen;
-                    if (bytesAfterHeaderLen + 10 >= batch.cachedMTU)
-                    {
-                        // undo the last write
-                        batch.batchedData.SetBitPosition(before);
-                        SendBatch(ref batch);
-                        batch.batchCount = 0;
-                        batch.batchedData.ResetPositionAndMode(false);
-
-                        // redo the last write
-                        NativeDeltaPacker<UnionRPCHeader>.WriteFunc(batch.batchedData, default, header);
-                        DeltaPackInteger.WriteIndex(batch.batchedData, default, contentLen);
-                    }
-                }
-
-                ++batch.batchCount;
-                batch.lastHeader = header;
-                batch.lastDataLen = contentLen;
-
-                if (hasContent)
-                    batch.batchedData.WriteBitDataWithoutConsumingIt(content);
-            }
+                QueueCached(targets[i], header, content, contentLen, channel, stateVersion);
 
             _queueMultiMarker.End();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool ShouldQueueDirect(IReadOnlyList<PlayerID> targets, in ObserverFilter filter,
+            bool hasFilter)
+        {
+            if (targets.Count < 3)
+                return true;
+
+            if (!hasFilter || targets.Count > 4)
+                return false;
+
+            int includedCount = 0;
+            for (int i = 0; i < targets.Count; i++)
+            {
+                if (!filter.ShouldSkip(targets[i]))
+                    includedCount++;
+            }
+            return includedCount < 3;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ValidateChannel(Channel channel)
+        {
+            if ((uint)channel > (uint)Channel.Unreliable)
+                throw new ArgumentOutOfRangeException(nameof(channel), channel, null);
+        }
+
         public unsafe void Queue(IReadOnlyList<PlayerID> targets, UnionRPCHeader header, BitData content, Channel channel, ObserverFilter filter = default)
         {
+            ValidateChannel(channel);
             _queueMultiMarker.Begin();
+            ulong stateVersion = NextStateVersion();
 
-            var contentLen = content.bitLength;
-            int contentByteLen = content.byteLength;
-            bool hasContent = contentLen.value > 0;
             bool hasFilter = filter.hasSkipA || filter.hasSkipB;
+
+            if (ShouldQueueDirect(targets, filter, hasFilter))
+            {
+                for (var i = targets.Count - 1; i >= 0; i--)
+                {
+                    var target = targets[i];
+                    if (!hasFilter || !filter.ShouldSkip(target))
+                        QueueDirect(target, header, content, channel, stateVersion);
+                }
+
+                _queueMultiMarker.End();
+                return;
+            }
+
+            ResetEntryCache();
+            var contentLen = content.bitLength;
 
             for (var i = targets.Count - 1; i >= 0; i--)
             {
                 var target = targets[i];
                 if (hasFilter && filter.ShouldSkip(target)) continue;
-
-                var batchIdx = GetBatchIndex(new BatchKey { playerId = target, channel = channel });
-                ref var batch = ref _batches[batchIdx];
-
-                int before = batch.batchedData.positionInBits;
-
-                NativeDeltaPacker<UnionRPCHeader>.WriteFunc(batch.batchedData, batch.lastHeader, header);
-                DeltaPackInteger.WriteIndex(batch.batchedData, batch.lastDataLen, contentLen);
-
-                // do some MTU checks past 1 batch
-                if (batch.batchCount > 0)
-                {
-                    int bytesAfterHeaderLen = batch.batchedData.positionInBytes + contentByteLen;
-                    if (bytesAfterHeaderLen + 10 >= batch.cachedMTU)
-                    {
-                        // undo the last write
-                        batch.batchedData.SetBitPosition(before);
-                        SendBatch(ref batch);
-                        batch.batchCount = 0;
-                        batch.batchedData.ResetPositionAndMode(false);
-
-                        // redo the last write
-                        NativeDeltaPacker<UnionRPCHeader>.WriteFunc(batch.batchedData, default, header);
-                        DeltaPackInteger.WriteIndex(batch.batchedData, default, contentLen);
-                    }
-                }
-
-                ++batch.batchCount;
-                batch.lastHeader = header;
-                batch.lastDataLen = contentLen;
-
-                if (hasContent)
-                    batch.batchedData.WriteBitDataWithoutConsumingIt(content);
+                QueueCached(target, header, content, contentLen, channel, stateVersion);
             }
 
             _queueMultiMarker.End();
         }
 
-        public unsafe void Queue(PlayerID target, UnionRPCHeader header, BitData content, Channel channel)
+        private unsafe void QueueDirect(PlayerID target, in UnionRPCHeader header, in BitData content,
+            Channel channel, ulong stateVersion)
         {
-            _queueSingleMarker.Begin();
-
-            var batchIdx = GetBatchIndex(new BatchKey { playerId = target, channel = channel });
+            var batchIdx = GetBatchIndex(target, channel);
             ref var batch = ref _batches[batchIdx];
 
             int before = batch.batchedData.positionInBits;
@@ -335,10 +510,18 @@ namespace PurrNet.Modules
             ++batch.batchCount;
             batch.lastHeader = header;
             batch.lastDataLen = contentLen;
+            batch.stateVersion = stateVersion;
 
             if (contentLen.value > 0)
                 batch.batchedData.WriteBitDataWithoutConsumingIt(content);
+        }
 
+        public unsafe void Queue(PlayerID target, UnionRPCHeader header, BitData content, Channel channel)
+        {
+            ValidateChannel(channel);
+            _queueSingleMarker.Begin();
+
+            QueueDirect(target, header, content, channel, NextStateVersion());
             _queueSingleMarker.End();
         }
 
@@ -349,6 +532,7 @@ namespace PurrNet.Modules
 
             _batchCount = 0;
             _batchIndexMap.Clear();
+            _nextStateVersion = 0;
         }
     }
 }

--- a/Assets/Tests/BitPacker.Tests/PackerBenchmark.cs
+++ b/Assets/Tests/BitPacker.Tests/PackerBenchmark.cs
@@ -1,7 +1,11 @@
+using System;
 using System.Diagnostics;
 using NUnit.Framework;
 using PurrNet;
+using PurrNet.Modules;
 using PurrNet.Packing;
+using PurrNet.Transports;
+using Unity.Collections;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
 
@@ -14,6 +18,16 @@ public class PackerBenchmark
 {
     const int WARMUP_TICKS = 10;
     const int MEASURE_TICKS = 100;
+
+    struct BenchmarkEntryCache
+    {
+        public UnionRPCHeader previousHeader;
+        public Size previousDataLen;
+        public ulong previousStateVersion;
+        public BitPacker data;
+        public int bitLength;
+        public bool isValid;
+    }
 
     [OneTimeSetUp]
     public void Init()
@@ -66,6 +80,154 @@ public class PackerBenchmark
             rpcId = new Size((uint)rpcId),
             targetId = null
         });
+    }
+
+    static void WriteBitDataLegacy(BitPacker destination, BitData content)
+    {
+        int bitLength = content.bitLength;
+        if (bitLength == 0) return;
+
+        var source = content.packer;
+        int sourcePosition = source.positionInBits;
+        source.SetBitPosition(content.bitOrigin);
+        destination.EnsureBitsExist(bitLength);
+        int chunks = bitLength >> 6;
+        byte excess = (byte)(bitLength & 63);
+
+        for (int i = 0; i < chunks; i++)
+            destination.WriteBitsWithoutChecks(source.ReadBits(64), 64);
+        if (excess != 0)
+            destination.WriteBitsWithoutChecks(source.ReadBits(excess), excess);
+
+        source.SetBitPosition(sourcePosition);
+    }
+
+    static void WriteByteAlignedBitsStateful(BitPacker destination, BitPacker source, int bits)
+    {
+        destination.EnsureBitsExist(bits);
+        int sourcePosition = source.positionInBits;
+        source.SetBitPosition(0);
+        int chunks = bits >> 6;
+        byte excess = (byte)(bits & 63);
+
+        for (int i = 0; i < chunks; i++)
+            destination.WriteBitsWithoutChecks(source.ReadBitsWithoutChecks(64), 64);
+        if (excess != 0)
+            destination.WriteBitsWithoutChecks(source.ReadBitsWithoutChecks(excess), excess);
+
+        source.SetBitPosition(sourcePosition);
+    }
+
+    static bool LogicalBitsEqual(BitPacker a, BitPacker b)
+    {
+        if (a.positionInBits != b.positionInBits)
+            return false;
+
+        int fullBytes = a.positionInBits >> 3;
+        var aBytes = a.ToByteData().span;
+        var bBytes = b.ToByteData().span;
+        if (!aBytes.Slice(0, fullBytes).SequenceEqual(bBytes.Slice(0, fullBytes)))
+            return false;
+
+        int remainingBits = a.positionInBits & 7;
+        if (remainingBits == 0)
+            return true;
+
+        int mask = (1 << remainingBits) - 1;
+        return (aBytes[fullBytes] & mask) == (bBytes[fullBytes] & mask);
+    }
+
+    static void GetBenchmarkEntry(ref BenchmarkEntryCache cacheA, ref BenchmarkEntryCache cacheB,
+        UnionRPCHeader previousHeader, Size previousDataLen, ulong previousStateVersion,
+        UnionRPCHeader header, BitData content, out BitPacker data, out int bitLength)
+    {
+        if (cacheA.isValid &&
+            (cacheA.previousStateVersion == previousStateVersion ||
+             (cacheA.previousDataLen.value == previousDataLen.value &&
+              cacheA.previousHeader.Equals(previousHeader))))
+        {
+            data = cacheA.data;
+            bitLength = cacheA.bitLength;
+            return;
+        }
+
+        if (cacheB.isValid &&
+            (cacheB.previousStateVersion == previousStateVersion ||
+             (cacheB.previousDataLen.value == previousDataLen.value &&
+              cacheB.previousHeader.Equals(previousHeader))))
+        {
+            data = cacheB.data;
+            bitLength = cacheB.bitLength;
+            return;
+        }
+
+        ref var cache = ref (cacheA.isValid ? ref cacheB : ref cacheA);
+        cache.data.ResetPositionAndMode(false);
+        DeltaPacker<UnionRPCHeader>.Write(cache.data, previousHeader, header);
+        DeltaPackInteger.WriteIndex(cache.data, previousDataLen, content.bitLength);
+        cache.data.WriteBitDataWithoutConsumingIt(content);
+        cache.previousHeader = previousHeader;
+        cache.previousDataLen = previousDataLen;
+        cache.previousStateVersion = previousStateVersion;
+        cache.bitLength = cache.data.positionInBits;
+        cache.isValid = true;
+
+        data = cache.data;
+        bitLength = cache.bitLength;
+    }
+
+    static void RunBaselineFanout(UnionRPCHeader[] headers, BitData[] contents, BitPacker[] batches,
+        UnionRPCHeader[] lastHeaders, Size[] lastSizes)
+    {
+        Array.Clear(lastHeaders, 0, lastHeaders.Length);
+        Array.Clear(lastSizes, 0, lastSizes.Length);
+        for (int i = 0; i < batches.Length; i++)
+            batches[i].ResetPositionAndMode(false);
+
+        for (int sender = 0; sender < headers.Length; sender++)
+        {
+            var content = contents[sender];
+            for (int recipient = headers.Length - 1; recipient >= 0; recipient--)
+            {
+                if (sender == recipient) continue;
+                var batch = batches[recipient];
+                DeltaPacker<UnionRPCHeader>.Write(batch, lastHeaders[recipient], headers[sender]);
+                DeltaPackInteger.WriteIndex(batch, lastSizes[recipient], content.bitLength);
+                WriteBitDataLegacy(batch, content);
+                lastHeaders[recipient] = headers[sender];
+                lastSizes[recipient] = content.bitLength;
+            }
+        }
+    }
+
+    static void RunCachedFanout(UnionRPCHeader[] headers, BitData[] contents, BitPacker[] batches,
+        UnionRPCHeader[] lastHeaders, Size[] lastSizes, ref BenchmarkEntryCache cacheA,
+        ref BenchmarkEntryCache cacheB, ulong[] lastStateVersions)
+    {
+        Array.Clear(lastHeaders, 0, lastHeaders.Length);
+        Array.Clear(lastSizes, 0, lastSizes.Length);
+        Array.Clear(lastStateVersions, 0, lastStateVersions.Length);
+        for (int i = 0; i < batches.Length; i++)
+            batches[i].ResetPositionAndMode(false);
+
+        for (int sender = 0; sender < headers.Length; sender++)
+        {
+            ulong stateVersion = (ulong)sender + 1;
+            cacheA.isValid = false;
+            cacheB.isValid = false;
+            var content = contents[sender];
+
+            for (int recipient = headers.Length - 1; recipient >= 0; recipient--)
+            {
+                if (sender == recipient) continue;
+                GetBenchmarkEntry(ref cacheA, ref cacheB, lastHeaders[recipient], lastSizes[recipient],
+                    lastStateVersions[recipient], headers[sender], content, out var entry, out int entryBitLength);
+                batches[recipient].WriteBitsWithoutConsumingItUnchecked(entry, entryBitLength);
+                lastHeaders[recipient] = headers[sender];
+                lastSizes[recipient] = content.bitLength;
+                lastStateVersions[recipient] = stateVersion;
+            }
+        }
     }
 
     // ───────────────────────────────────────────────
@@ -259,6 +421,207 @@ public class PackerBenchmark
                   $"{deltaOpsPerTick:N0} delta packs/tick | " +
                   $"{msPerTick:F3} ms/tick | " +
                   $"{deltaOps:N0} total ops in {sw.ElapsedMilliseconds} ms");
+    }
+
+    [Test]
+    [TestCase(10)]
+    [TestCase(25)]
+    [TestCase(50)]
+    [TestCase(100)]
+    public void Benchmark_RPCBatch_FanoutCache(int playerCount)
+    {
+        var headers = new UnionRPCHeader[playerCount];
+        var payloadPackers = new BitPacker[playerCount];
+        var contents = new BitData[playerCount];
+        var baselineBatches = new BitPacker[playerCount];
+        var cachedBatches = new BitPacker[playerCount];
+
+        for (int i = 0; i < playerCount; i++)
+        {
+            headers[i] = MakeHeader(i + 1, i + 1, i % 20);
+            payloadPackers[i] = BitPackerPool.Get();
+            PackTypicalRPCPayload(payloadPackers[i], i);
+            contents[i] = new BitData(payloadPackers[i]);
+            baselineBatches[i] = BitPackerPool.Get();
+            cachedBatches[i] = BitPackerPool.Get();
+        }
+
+        var baselineLastHeaders = new UnionRPCHeader[playerCount];
+        var baselineLastSizes = new Size[playerCount];
+        var cachedLastHeaders = new UnionRPCHeader[playerCount];
+        var cachedLastSizes = new Size[playerCount];
+        var cachedLastStateVersions = new ulong[playerCount];
+        var cacheA = new BenchmarkEntryCache { data = BitPackerPool.Get() };
+        var cacheB = new BenchmarkEntryCache { data = BitPackerPool.Get() };
+
+        for (int i = 0; i < WARMUP_TICKS; i++)
+        {
+            RunBaselineFanout(headers, contents, baselineBatches, baselineLastHeaders, baselineLastSizes);
+            RunCachedFanout(headers, contents, cachedBatches, cachedLastHeaders, cachedLastSizes,
+                ref cacheA, ref cacheB, cachedLastStateVersions);
+        }
+
+        var baselineWatch = Stopwatch.StartNew();
+        for (int i = 0; i < MEASURE_TICKS; i++)
+            RunBaselineFanout(headers, contents, baselineBatches, baselineLastHeaders, baselineLastSizes);
+        baselineWatch.Stop();
+
+        var cachedWatch = Stopwatch.StartNew();
+        for (int i = 0; i < MEASURE_TICKS; i++)
+            RunCachedFanout(headers, contents, cachedBatches, cachedLastHeaders, cachedLastSizes,
+                ref cacheA, ref cacheB, cachedLastStateVersions);
+        cachedWatch.Stop();
+
+        for (int i = 0; i < playerCount; i++)
+        {
+            Assert.That(cachedBatches[i].positionInBits, Is.EqualTo(baselineBatches[i].positionInBits));
+            Assert.That(LogicalBitsEqual(cachedBatches[i], baselineBatches[i]),
+                Is.True, $"Cached batch differed for recipient {i}.");
+        }
+
+        double baselineMs = baselineWatch.Elapsed.TotalMilliseconds / MEASURE_TICKS;
+        double cachedMs = cachedWatch.Elapsed.TotalMilliseconds / MEASURE_TICKS;
+        Debug.Log($"[Batch Fanout Cache] {playerCount} players | baseline {baselineMs:F3} ms/tick | " +
+                  $"cached {cachedMs:F3} ms/tick | {baselineMs / cachedMs:F2}x faster");
+
+        cacheA.data.Dispose();
+        cacheB.data.Dispose();
+        for (int i = 0; i < playerCount; i++)
+        {
+            payloadPackers[i].Dispose();
+            baselineBatches[i].Dispose();
+            cachedBatches[i].Dispose();
+        }
+    }
+
+    [Test]
+    public void Benchmark_RPCBatch_IndexLookup()
+    {
+        const int playerCount = 100;
+        const int channelCount = 4;
+        const int passes = 10_000;
+        var keys = new BatchKey[playerCount * channelCount];
+        var original = new NativeHashMap<BatchKey, int>(keys.Length, Allocator.Temp);
+        using var optimized = new BatchIndexMap(playerCount);
+
+        int keyIndex = 0;
+        for (int player = 1; player <= playerCount; player++)
+        {
+            for (int channel = 0; channel < channelCount; channel++)
+            {
+                var key = new BatchKey
+                {
+                    playerId = new PlayerID((ulong)player, false),
+                    channel = (Channel)channel
+                };
+                keys[keyIndex] = key;
+                original[key] = keyIndex;
+                optimized.Set(key.playerId.id.value, key.channel, keyIndex);
+                keyIndex++;
+            }
+        }
+
+        long warmupSum = 0;
+        for (int pass = 0; pass < 100; pass++)
+        {
+            for (int i = 0; i < keys.Length; i++)
+            {
+                var key = keys[i];
+                warmupSum += original[key];
+                optimized.TryGetValue(key.playerId.id.value, key.channel, out int optimizedValue);
+                warmupSum += optimizedValue;
+            }
+        }
+        Assert.That(warmupSum, Is.GreaterThan(0));
+
+        long originalSum = 0;
+        var originalWatch = Stopwatch.StartNew();
+        for (int pass = 0; pass < passes; pass++)
+            for (int i = 0; i < keys.Length; i++)
+                originalSum += original[keys[i]];
+        originalWatch.Stop();
+
+        long optimizedSum = 0;
+        var optimizedWatch = Stopwatch.StartNew();
+        for (int pass = 0; pass < passes; pass++)
+        {
+            for (int i = 0; i < keys.Length; i++)
+            {
+                var key = keys[i];
+                optimized.TryGetValue(key.playerId.id.value, key.channel, out int value);
+                optimizedSum += value;
+            }
+        }
+        optimizedWatch.Stop();
+
+        original.Dispose();
+        Assert.That(optimizedSum, Is.EqualTo(originalSum));
+        Debug.Log($"[Batch Index Lookup] 4M lookups | original {originalWatch.Elapsed.TotalMilliseconds:F2} ms | " +
+                   $"optimized {optimizedWatch.Elapsed.TotalMilliseconds:F2} ms | " +
+                   $"{originalWatch.Elapsed.TotalMilliseconds / optimizedWatch.Elapsed.TotalMilliseconds:F2}x faster");
+    }
+
+    [Test]
+    [TestCase(1)]
+    [TestCase(4)]
+    [TestCase(8)]
+    [TestCase(12)]
+    [TestCase(16)]
+    [TestCase(32)]
+    [TestCase(64)]
+    [TestCase(128)]
+    [TestCase(256)]
+    [TestCase(512)]
+    [TestCase(1400)]
+    public void Benchmark_UnalignedCachedEntryCopy(int byteCount)
+    {
+        var bytes = new byte[byteCount];
+        for (int i = 0; i < bytes.Length; i++)
+            bytes[i] = (byte)(i * 31 + 17);
+
+        using var source = BitPackerPool.Get();
+        using var statefulDestination = BitPackerPool.Get();
+        using var optimizedDestination = BitPackerPool.Get();
+        source.WriteBytes(bytes);
+        int sourcePosition = source.positionInBits;
+        int bits = (byteCount << 3) - 3;
+        int iterations = Math.Max(10_000, 10_000_000 / byteCount);
+
+        for (int i = 0; i < 100; i++)
+        {
+            statefulDestination.ResetPositionAndMode(false);
+            statefulDestination.WriteBit(true);
+            WriteByteAlignedBitsStateful(statefulDestination, source, bits);
+            optimizedDestination.ResetPositionAndMode(false);
+            optimizedDestination.WriteBit(true);
+            optimizedDestination.WriteBitsWithoutConsumingItUnchecked(source, bits);
+        }
+
+        var statefulWatch = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+        {
+            statefulDestination.ResetPositionAndMode(false);
+            statefulDestination.WriteBit(true);
+            WriteByteAlignedBitsStateful(statefulDestination, source, bits);
+        }
+        statefulWatch.Stop();
+
+        var optimizedWatch = Stopwatch.StartNew();
+        for (int i = 0; i < iterations; i++)
+        {
+            optimizedDestination.ResetPositionAndMode(false);
+            optimizedDestination.WriteBit(true);
+            optimizedDestination.WriteBitsWithoutConsumingItUnchecked(source, bits);
+        }
+        optimizedWatch.Stop();
+
+        Assert.That(source.positionInBits, Is.EqualTo(sourcePosition));
+        Assert.That(optimizedDestination.positionInBits, Is.EqualTo(statefulDestination.positionInBits));
+        Assert.That(LogicalBitsEqual(optimizedDestination, statefulDestination), Is.True);
+        Debug.Log($"[Unaligned Cached Copy] {byteCount} bytes | stateful " +
+                  $"{statefulWatch.Elapsed.TotalMilliseconds:F2} ms | optimized " +
+                  $"{optimizedWatch.Elapsed.TotalMilliseconds:F2} ms | " +
+                  $"{statefulWatch.Elapsed.TotalMilliseconds / optimizedWatch.Elapsed.TotalMilliseconds:F2}x faster");
     }
 
     // ───────────────────────────────────────────────

--- a/Assets/Tests/BitPacker.Tests/PackerBenchmark.cs
+++ b/Assets/Tests/BitPacker.Tests/PackerBenchmark.cs
@@ -29,6 +29,14 @@ public class PackerBenchmark
         public bool isValid;
     }
 
+    sealed class NoopRPCBatchBackend : IRPCBatchBackend
+    {
+        public int GetMTU(PlayerID player, Channel channel, bool asServer) => int.MaxValue;
+        public void Send(PlayerID player, RPCBatchPacket data, Channel channel) { }
+        public void Subscribe(PlayerBroadcastDelegate<RPCBatchPacket> callback) { }
+        public void Unsubscribe(PlayerBroadcastDelegate<RPCBatchPacket> callback) { }
+    }
+
     [OneTimeSetUp]
     public void Init()
     {
@@ -142,7 +150,7 @@ public class PackerBenchmark
         UnionRPCHeader header, BitData content, out BitPacker data, out int bitLength)
     {
         if (cacheA.isValid &&
-            (cacheA.previousStateVersion == previousStateVersion ||
+            ((previousStateVersion != 0 && cacheA.previousStateVersion == previousStateVersion) ||
              (cacheA.previousDataLen.value == previousDataLen.value &&
               cacheA.previousHeader.Equals(previousHeader))))
         {
@@ -152,7 +160,7 @@ public class PackerBenchmark
         }
 
         if (cacheB.isValid &&
-            (cacheB.previousStateVersion == previousStateVersion ||
+            ((previousStateVersion != 0 && cacheB.previousStateVersion == previousStateVersion) ||
              (cacheB.previousDataLen.value == previousDataLen.value &&
               cacheB.previousHeader.Equals(previousHeader))))
         {
@@ -559,6 +567,59 @@ public class PackerBenchmark
         Debug.Log($"[Batch Index Lookup] 4M lookups | original {originalWatch.Elapsed.TotalMilliseconds:F2} ms | " +
                    $"optimized {optimizedWatch.Elapsed.TotalMilliseconds:F2} ms | " +
                    $"{originalWatch.Elapsed.TotalMilliseconds / optimizedWatch.Elapsed.TotalMilliseconds:F2}x faster");
+    }
+
+    [Test]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void Benchmark_RPCBatch_DirectQueue(int recipientCount)
+    {
+        const int warmupOperations = 5_000;
+        const int measuredOperations = 250_000;
+        const int sampleCount = 5;
+        const int flushInterval = 64;
+        var targets = new PlayerID[recipientCount];
+        for (int i = 0; i < targets.Length; i++)
+            targets[i] = new PlayerID((ulong)(i + 1), false);
+
+        var backend = new NoopRPCBatchBackend();
+        using var batch = new RPCBatch(backend, (_, _, _, _) => { });
+        using var payload = BitPackerPool.Get();
+        PackTypicalRPCPayload(payload, 7);
+        var content = new BitData(payload);
+
+        void Run(int operationCount)
+        {
+            for (int operation = 0; operation < operationCount; operation++)
+            {
+                var header = MakeHeader(1, 1, operation & 15);
+                if (recipientCount == 1)
+                    batch.Queue(targets[0], header, content, Channel.ReliableOrdered);
+                else
+                    batch.Queue(targets, header, content, Channel.ReliableOrdered);
+
+                if ((operation & (flushInterval - 1)) == flushInterval - 1)
+                    batch.Flush();
+            }
+            batch.Flush();
+        }
+
+        Run(warmupOperations);
+        var samples = new double[sampleCount];
+        for (int sample = 0; sample < sampleCount; sample++)
+        {
+            var watch = Stopwatch.StartNew();
+            Run(measuredOperations);
+            watch.Stop();
+            samples[sample] = watch.Elapsed.TotalMilliseconds * 1_000_000.0 /
+                              (measuredOperations * recipientCount);
+        }
+
+        Array.Sort(samples);
+        double nsPerRecipient = samples[sampleCount / 2];
+        Debug.Log($"[Batch Direct Queue] {recipientCount} recipient(s) | " +
+                  $"median {nsPerRecipient:F1} ns/recipient | " +
+                  $"range {samples[0]:F1}-{samples[sampleCount - 1]:F1}");
     }
 
     [Test]

--- a/Assets/Tests/BitPacker.Tests/RPCBatchTests.cs
+++ b/Assets/Tests/BitPacker.Tests/RPCBatchTests.cs
@@ -1,0 +1,446 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using PurrNet;
+using PurrNet.Modules;
+using PurrNet.Packing;
+using PurrNet.Transports;
+
+public class RPCBatchTests
+{
+    sealed class CapturedBatch
+    {
+        public PlayerID target;
+        public Channel channel;
+        public Size count;
+        public BitPacker data;
+    }
+
+    sealed class TestRPCBatchBackend : IRPCBatchBackend, IDisposable
+    {
+        readonly List<CapturedBatch> _sent = new List<CapturedBatch>();
+        PlayerBroadcastDelegate<RPCBatchPacket> _callback;
+
+        public int mtu = int.MaxValue;
+        public PlayerID deliveringTarget { get; private set; }
+        public Channel deliveringChannel { get; private set; }
+        public IReadOnlyList<CapturedBatch> sent => _sent;
+
+        public int GetMTU(PlayerID player, Channel channel, bool asServer) => mtu;
+
+        public void Send(PlayerID player, RPCBatchPacket packet, Channel channel)
+        {
+            var copy = BitPackerPool.Get();
+            copy.WriteBitDataWithoutConsumingIt(packet.data);
+            _sent.Add(new CapturedBatch
+            {
+                target = player,
+                channel = channel,
+                count = packet.count,
+                data = copy
+            });
+        }
+
+        public void Subscribe(PlayerBroadcastDelegate<RPCBatchPacket> callback)
+        {
+            if (_callback != null)
+                throw new InvalidOperationException("Only one RPCBatch subscription is supported by this test backend.");
+            _callback = callback;
+        }
+
+        public void Unsubscribe(PlayerBroadcastDelegate<RPCBatchPacket> callback)
+        {
+            if (_callback == callback)
+                _callback = null;
+        }
+
+        public int Count(PlayerID target, Channel channel)
+        {
+            int count = 0;
+            for (int i = 0; i < _sent.Count; i++)
+            {
+                if (_sent[i].target == target && _sent[i].channel == channel)
+                    count++;
+            }
+            return count;
+        }
+
+        public void DeliverAll()
+        {
+            if (_callback == null)
+                throw new InvalidOperationException("RPCBatch is not subscribed.");
+
+            for (int i = 0; i < _sent.Count; i++)
+            {
+                var captured = _sent[i];
+                deliveringTarget = captured.target;
+                deliveringChannel = captured.channel;
+
+                try
+                {
+                    _callback(new PlayerID(999, false), new RPCBatchPacket
+                    {
+                        count = captured.count,
+                        data = new BitData(captured.data)
+                    }, true);
+                }
+                finally
+                {
+                    captured.data.Dispose();
+                    captured.data = null;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            for (int i = 0; i < _sent.Count; i++)
+            {
+                _sent[i].data?.Dispose();
+                _sent[i].data = null;
+            }
+        }
+    }
+
+    static readonly Channel[] AllChannels =
+    {
+        Channel.ReliableUnordered,
+        Channel.UnreliableSequenced,
+        Channel.ReliableOrdered,
+        Channel.Unreliable
+    };
+
+    [OneTimeSetUp]
+    public void Init()
+    {
+        NetworkManager.LoadOrGenerateHashes();
+    }
+
+    static UnionRPCHeader MakeHeader(Channel channel, int sequence)
+    {
+        return new UnionRPCHeader(new NetworkIdentityRPCHeader
+        {
+            senderId = new PlayerID((ulong)(100 + (int)channel), false),
+            networkId = new NetworkID((ulong)(200 + (int)channel)),
+            sceneId = new SceneID(0),
+            rpcId = new Size((uint)sequence),
+            targetId = null
+        });
+    }
+
+    static void WritePayload(BitPacker payload, int sequence, int byteCount)
+    {
+        payload.ResetPositionAndMode(false);
+        for (int i = 0; i < byteCount; i++)
+            payload.WriteBits((ulong)(byte)(sequence + i), 8);
+    }
+
+    static void RecordReceived(TestRPCBatchBackend backend,
+        Dictionary<BatchKey, List<int>> received, UnionRPCHeader header, BitData content)
+    {
+        int sequence;
+        using (content.AutoScope())
+            sequence = (int)content.packer.ReadBits(8);
+
+        Assert.That(header.rpcId.value, Is.EqualTo((uint)sequence));
+        var key = new BatchKey
+        {
+            playerId = backend.deliveringTarget,
+            channel = backend.deliveringChannel
+        };
+
+        if (!received.TryGetValue(key, out var values))
+        {
+            values = new List<int>();
+            received.Add(key, values);
+        }
+        values.Add(sequence);
+    }
+
+    [Test]
+    public void BatchIndexMapKeepsChannelsIndependent()
+    {
+        using var map = new BatchIndexMap(4);
+        var player = new PlayerID(42, false);
+        var channels = new[]
+        {
+            Channel.ReliableUnordered,
+            Channel.UnreliableSequenced,
+            Channel.ReliableOrdered,
+            Channel.Unreliable
+        };
+
+        for (int i = 0; i < channels.Length; i++)
+            map.Set(player.id.value, channels[i], 100 + i);
+
+        for (int i = 0; i < channels.Length; i++)
+        {
+            Assert.That(map.TryGetValue(player.id.value, channels[i], out int value),
+                Is.True);
+            Assert.That(value, Is.EqualTo(100 + i));
+        }
+
+        var reliableOrdered = new BatchKey { playerId = player, channel = Channel.ReliableOrdered };
+        Assert.That(map.Remove(reliableOrdered.playerId.id.value, reliableOrdered.channel), Is.True);
+        Assert.That(map.TryGetValue(reliableOrdered.playerId.id.value, reliableOrdered.channel, out _), Is.False);
+        Assert.That(map.TryGetValue(player.id.value, Channel.ReliableUnordered, out int reliableUnordered),
+            Is.True);
+        Assert.That(reliableUnordered, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void BatchIndexMapClearClearsEveryChannel()
+    {
+        using var map = new BatchIndexMap(4);
+        var player = new PlayerID(7, false);
+        var channels = new[]
+        {
+            Channel.ReliableUnordered,
+            Channel.UnreliableSequenced,
+            Channel.ReliableOrdered,
+            Channel.Unreliable
+        };
+
+        for (int i = 0; i < channels.Length; i++)
+            map.Set(player.id.value, channels[i], i);
+
+        map.Clear();
+
+        for (int i = 0; i < channels.Length; i++)
+            Assert.That(map.TryGetValue(player.id.value, channels[i], out _), Is.False);
+    }
+
+    [Test]
+    public void BatchIndexMapUsesEveryPlayerIdBit()
+    {
+        using var map = new BatchIndexMap(5);
+        var ids = new[]
+        {
+            0UL,
+            1UL,
+            0x0000000100000001UL,
+            0xFFFFFFFF00000001UL,
+            ulong.MaxValue
+        };
+
+        for (int i = 0; i < ids.Length; i++)
+            map.Set(ids[i], Channel.ReliableOrdered, 100 + i);
+
+        for (int i = 0; i < ids.Length; i++)
+        {
+            Assert.That(map.TryGetValue(ids[i], Channel.ReliableOrdered, out int value), Is.True);
+            Assert.That(value, Is.EqualTo(100 + i));
+        }
+    }
+
+    [Test]
+    public void QueueRejectsUndefinedChannelBeforeIndexLookup()
+    {
+        using var backend = new TestRPCBatchBackend();
+        using var batch = new RPCBatch(backend, (_, _, _, _) => { });
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            batch.Queue(new PlayerID(1, false), default, default, (Channel)byte.MaxValue));
+        Assert.That(backend.sent, Is.Empty);
+    }
+
+    [Test]
+    public void StateVersionWrapDoesNotAliasDivergedRecipients()
+    {
+        var targets = new[]
+        {
+            new PlayerID(41, false),
+            new PlayerID(42, false),
+            new PlayerID(43, false)
+        };
+        var received = new Dictionary<BatchKey, List<int>>();
+        using var backend = new TestRPCBatchBackend();
+        using var batch = new RPCBatch(backend,
+            (_, header, content, _) => RecordReceived(backend, received, header, content));
+        using var payload = BitPackerPool.Get();
+
+        for (int i = 0; i < targets.Length; i++)
+        {
+            int sequence = i + 1;
+            WritePayload(payload, sequence, 8);
+            batch.Queue(targets[i], MakeHeader(Channel.ReliableOrdered, sequence), new BitData(payload),
+                Channel.ReliableOrdered);
+        }
+
+        var versionField = typeof(RPCBatch).GetField("_nextStateVersion",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(versionField, Is.Not.Null);
+        versionField.SetValue(batch, ulong.MaxValue);
+
+        WritePayload(payload, 4, 8);
+        batch.Queue(targets[1], MakeHeader(Channel.ReliableOrdered, 4), new BitData(payload),
+            Channel.ReliableOrdered);
+
+        WritePayload(payload, 5, 8);
+        batch.Queue(targets, MakeHeader(Channel.ReliableOrdered, 5), new BitData(payload),
+            Channel.ReliableOrdered);
+
+        batch.Flush();
+        backend.DeliverAll();
+
+        Assert.That(received[new BatchKey
+        {
+            playerId = targets[0],
+            channel = Channel.ReliableOrdered
+        }], Is.EqualTo(new[] { 1, 5 }));
+        Assert.That(received[new BatchKey
+        {
+            playerId = targets[1],
+            channel = Channel.ReliableOrdered
+        }], Is.EqualTo(new[] { 2, 4, 5 }));
+        Assert.That(received[new BatchKey
+        {
+            playerId = targets[2],
+            channel = Channel.ReliableOrdered
+        }], Is.EqualTo(new[] { 3, 5 }));
+    }
+
+    [Test]
+    public void QueueFanoutPreservesOrderAndChannelAcrossMtuSplits()
+    {
+        var targets = new[]
+        {
+            new PlayerID(11, false),
+            new PlayerID(12, false),
+            new PlayerID(13, false)
+        };
+        var received = new Dictionary<BatchKey, List<int>>();
+        using var backend = new TestRPCBatchBackend { mtu = 64 };
+        using var batch = new RPCBatch(backend,
+            (_, header, content, _) => RecordReceived(backend, received, header, content));
+        using var payload = BitPackerPool.Get();
+
+        const int sequenceCount = 6;
+        for (int sequence = 0; sequence < sequenceCount; sequence++)
+        {
+            for (int channelIdx = 0; channelIdx < AllChannels.Length; channelIdx++)
+            {
+                var channel = AllChannels[channelIdx];
+                WritePayload(payload, sequence, 32);
+                batch.Queue(targets, MakeHeader(channel, sequence), new BitData(payload), channel);
+            }
+        }
+
+        batch.Flush();
+
+        for (int targetIdx = 0; targetIdx < targets.Length; targetIdx++)
+        {
+            for (int channelIdx = 0; channelIdx < AllChannels.Length; channelIdx++)
+            {
+                Assert.That(backend.Count(targets[targetIdx], AllChannels[channelIdx]), Is.GreaterThan(1),
+                    $"Expected forced MTU splits for target {targets[targetIdx]} on {AllChannels[channelIdx]}.");
+            }
+        }
+
+        backend.DeliverAll();
+
+        for (int targetIdx = 0; targetIdx < targets.Length; targetIdx++)
+        {
+            for (int channelIdx = 0; channelIdx < AllChannels.Length; channelIdx++)
+            {
+                var key = new BatchKey
+                {
+                    playerId = targets[targetIdx],
+                    channel = AllChannels[channelIdx]
+                };
+                Assert.That(received.TryGetValue(key, out var values), Is.True);
+                Assert.That(values, Has.Count.EqualTo(sequenceCount));
+                for (int sequence = 0; sequence < sequenceCount; sequence++)
+                    Assert.That(values[sequence], Is.EqualTo(sequence));
+            }
+        }
+    }
+
+    [Test]
+    public void FlushChannelSendsOnlyRequestedChannelAndKeepsOtherBatchesQueued()
+    {
+        var targets = new[]
+        {
+            new PlayerID(21, false),
+            new PlayerID(22, false),
+            new PlayerID(23, false)
+        };
+        var received = new Dictionary<BatchKey, List<int>>();
+        using var backend = new TestRPCBatchBackend();
+        using var batch = new RPCBatch(backend,
+            (_, header, content, _) => RecordReceived(backend, received, header, content));
+        using var payload = BitPackerPool.Get();
+
+        for (int sequence = 0; sequence < 3; sequence++)
+        {
+            WritePayload(payload, sequence, 8);
+            batch.Queue(targets, MakeHeader(Channel.ReliableOrdered, sequence), new BitData(payload),
+                Channel.ReliableOrdered);
+            batch.Queue(targets, MakeHeader(Channel.Unreliable, sequence), new BitData(payload),
+                Channel.Unreliable);
+        }
+
+        batch.FlushChannel(Channel.ReliableOrdered);
+        Assert.That(backend.sent, Has.Count.EqualTo(targets.Length));
+        for (int i = 0; i < backend.sent.Count; i++)
+            Assert.That(backend.sent[i].channel, Is.EqualTo(Channel.ReliableOrdered));
+
+        batch.Flush();
+        Assert.That(backend.sent, Has.Count.EqualTo(targets.Length * 2));
+        for (int i = targets.Length; i < backend.sent.Count; i++)
+            Assert.That(backend.sent[i].channel, Is.EqualTo(Channel.Unreliable));
+
+        backend.DeliverAll();
+        for (int targetIdx = 0; targetIdx < targets.Length; targetIdx++)
+        {
+            for (int channelIdx = 0; channelIdx < 2; channelIdx++)
+            {
+                var channel = channelIdx == 0 ? Channel.ReliableOrdered : Channel.Unreliable;
+                var key = new BatchKey { playerId = targets[targetIdx], channel = channel };
+                Assert.That(received.TryGetValue(key, out var values), Is.True);
+                Assert.That(values, Is.EqualTo(new[] { 0, 1, 2 }));
+            }
+        }
+    }
+
+    [Test]
+    public void FilteredSmallFanoutSendsOnlyToIncludedTargets()
+    {
+        var targets = new[]
+        {
+            new PlayerID(31, false),
+            new PlayerID(32, false),
+            new PlayerID(33, false),
+            new PlayerID(34, false)
+        };
+        var filter = new ObserverFilter(targets[0], true, targets[3], true);
+        var received = new Dictionary<BatchKey, List<int>>();
+        using var backend = new TestRPCBatchBackend();
+        using var batch = new RPCBatch(backend,
+            (_, header, content, _) => RecordReceived(backend, received, header, content));
+        using var payload = BitPackerPool.Get();
+
+        WritePayload(payload, 0, 8);
+        batch.Queue(targets, MakeHeader(Channel.ReliableOrdered, 0), new BitData(payload),
+            Channel.ReliableOrdered, filter);
+        batch.Flush();
+
+        Assert.That(backend.Count(targets[0], Channel.ReliableOrdered), Is.Zero);
+        Assert.That(backend.Count(targets[1], Channel.ReliableOrdered), Is.EqualTo(1));
+        Assert.That(backend.Count(targets[2], Channel.ReliableOrdered), Is.EqualTo(1));
+        Assert.That(backend.Count(targets[3], Channel.ReliableOrdered), Is.Zero);
+
+        backend.DeliverAll();
+        Assert.That(received.ContainsKey(new BatchKey
+        {
+            playerId = targets[0],
+            channel = Channel.ReliableOrdered
+        }), Is.False);
+        Assert.That(received.ContainsKey(new BatchKey
+        {
+            playerId = targets[3],
+            channel = Channel.ReliableOrdered
+        }), Is.False);
+    }
+}

--- a/Assets/Tests/BitPacker.Tests/RPCBatchTests.cs
+++ b/Assets/Tests/BitPacker.Tests/RPCBatchTests.cs
@@ -443,4 +443,81 @@ public class RPCBatchTests
             channel = Channel.ReliableOrdered
         }), Is.False);
     }
+
+    [Test]
+    public void HundredRecipientReliableOrderedFanoutSurvivesDivergenceAndMtuSplits()
+    {
+        const int targetCount = 100;
+        const int sequenceCount = 96;
+        var targets = new PlayerID[targetCount];
+        var expected = new Dictionary<BatchKey, List<int>>();
+        var received = new Dictionary<BatchKey, List<int>>();
+
+        for (int i = 0; i < targets.Length; i++)
+        {
+            targets[i] = new PlayerID((ulong)(1000 + i), false);
+            expected[new BatchKey
+            {
+                playerId = targets[i],
+                channel = Channel.ReliableOrdered
+            }] = new List<int>();
+        }
+
+        using var backend = new TestRPCBatchBackend { mtu = 192 };
+        using var batch = new RPCBatch(backend,
+            (_, header, content, _) => RecordReceived(backend, received, header, content));
+        using var payload = BitPackerPool.Get();
+
+        for (int sequence = 0; sequence < sequenceCount; sequence++)
+        {
+            int singledOut = (sequence * 17) % targetCount;
+            if ((sequence & 3) == 0)
+            {
+                WritePayload(payload, sequence, 24 + sequence % 41);
+                batch.Queue(targets[singledOut], MakeHeader(Channel.ReliableOrdered, sequence),
+                    new BitData(payload), Channel.ReliableOrdered);
+                expected[new BatchKey
+                {
+                    playerId = targets[singledOut],
+                    channel = Channel.ReliableOrdered
+                }].Add(sequence);
+            }
+
+            int skipA = (sequence * 7 + 3) % targetCount;
+            int skipB = (sequence * 11 + 5) % targetCount;
+            var filter = new ObserverFilter(targets[skipA], true, targets[skipB], true);
+            WritePayload(payload, sequence, 32 + sequence % 73);
+            batch.Queue(targets, MakeHeader(Channel.ReliableOrdered, sequence), new BitData(payload),
+                Channel.ReliableOrdered, filter);
+
+            for (int target = 0; target < targets.Length; target++)
+            {
+                if (target != skipA && target != skipB)
+                {
+                    expected[new BatchKey
+                    {
+                        playerId = targets[target],
+                        channel = Channel.ReliableOrdered
+                    }].Add(sequence);
+                }
+            }
+
+            if (sequence % 13 == 12)
+                batch.FlushChannel(Channel.ReliableOrdered);
+        }
+
+        batch.Flush();
+        backend.DeliverAll();
+
+        for (int i = 0; i < targets.Length; i++)
+        {
+            var key = new BatchKey
+            {
+                playerId = targets[i],
+                channel = Channel.ReliableOrdered
+            };
+            Assert.That(received.TryGetValue(key, out var actual), Is.True, $"No RPCs received by {targets[i]}.");
+            Assert.That(actual, Is.EqualTo(expected[key]), $"Reliable-ordered stream diverged for {targets[i]}.");
+        }
+    }
 }

--- a/Assets/Tests/BitPacker.Tests/RPCBatchTests.cs.meta
+++ b/Assets/Tests/BitPacker.Tests/RPCBatchTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 679c5d9ee007d6f44b8c565b736c2522

--- a/Assets/Tests/BitPacker.Tests/TestBitData.cs
+++ b/Assets/Tests/BitPacker.Tests/TestBitData.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using PurrNet;
 using PurrNet.Packing;
@@ -96,5 +97,190 @@ public class TestBitData
         var resultActual = Packer<string>.Read(readPacker);
         Assert.That(resultTest, Is.EqualTo("test"));
         Assert.That(resultActual, Is.EqualTo("actual"));
+    }
+
+    [Test]
+    public void TestAlignedCopyPreservesPartialByteTail()
+    {
+        using var source = BitPackerPool.Get();
+        using var destination = BitPackerPool.Get();
+        const ulong value = 0b1_0110_1101_0011;
+
+        source.WriteBits(value, 13);
+        int sourcePosition = source.positionInBits;
+
+        destination.WriteBits(0xAB, 8);
+        destination.WriteBits(0xFFFF, 16);
+        destination.SetBitPosition(8);
+        destination.WriteBitDataWithoutConsumingIt(new BitData(source, 0, 13));
+
+        Assert.That(source.positionInBits, Is.EqualTo(sourcePosition));
+        Assert.That(destination.positionInBits, Is.EqualTo(21));
+
+        destination.ResetPositionAndMode(true);
+        Assert.That(destination.ReadBits(8), Is.EqualTo(0xAB));
+        Assert.That(destination.ReadBits(13), Is.EqualTo(value));
+        Assert.That(destination.ReadBits(3), Is.EqualTo(0b111));
+    }
+
+    [Test]
+    public void TestUnalignedBitDataCopyPreservesSourcePosition()
+    {
+        using var source = BitPackerPool.Get();
+        using var destination = BitPackerPool.Get();
+        const ulong first = 0xFEDCBA9876543210;
+        const ulong second = 0b1_1010_0110_1101;
+
+        source.WriteBits(0b10101, 5);
+        int origin = source.positionInBits;
+        source.WriteBits(first, 64);
+        source.WriteBits(second, 13);
+        int sourcePosition = source.positionInBits;
+
+        destination.WriteBits(0b101, 3);
+        destination.WriteBitDataWithoutConsumingIt(new BitData(source, origin, 77));
+
+        Assert.That(source.positionInBits, Is.EqualTo(sourcePosition));
+        destination.ResetPositionAndMode(true);
+        Assert.That(destination.ReadBits(3), Is.EqualTo(0b101));
+        Assert.That(destination.ReadBits(64), Is.EqualTo(first));
+        Assert.That(destination.ReadBits(13), Is.EqualTo(second));
+    }
+
+    [Test]
+    public void TestUnalignedBitPackerCopyPreservesSourcePosition()
+    {
+        using var source = BitPackerPool.Get();
+        using var destination = BitPackerPool.Get();
+        const ulong value = 0x0123456789ABCDEF;
+
+        source.WriteBits(value, 64);
+        int sourcePosition = source.positionInBits;
+        destination.WriteBits(0b11, 2);
+        destination.WriteBitsWithoutConsumingIt(source, 64);
+
+        Assert.That(source.positionInBits, Is.EqualTo(sourcePosition));
+        destination.ResetPositionAndMode(true);
+        Assert.That(destination.ReadBits(2), Is.EqualTo(0b11));
+        Assert.That(destination.ReadBits(64), Is.EqualTo(value));
+    }
+
+    [Test]
+    public void TestLargeByteAlignedSourceCopyIntoUnalignedDestination()
+    {
+        using var source = BitPackerPool.Get();
+        using var destination = BitPackerPool.Get();
+        const ulong first = 0x0123456789ABCDEF;
+        const ulong second = 0xFEDCBA9876543210;
+        const ulong third = 0xA55AA55AA55AA55A;
+
+        source.WriteBits(first, 64);
+        source.WriteBits(second, 64);
+        source.WriteBits(third, 64);
+        source.WriteBits(0b1_1011, 5);
+        int sourcePosition = source.positionInBits;
+
+        destination.WriteBits(0b101, 3);
+        destination.WriteBitsWithoutConsumingIt(source, sourcePosition);
+
+        Assert.That(source.positionInBits, Is.EqualTo(sourcePosition));
+        destination.ResetPositionAndMode(true);
+        Assert.That(destination.ReadBits(3), Is.EqualTo(0b101));
+        Assert.That(destination.ReadBits(64), Is.EqualTo(first));
+        Assert.That(destination.ReadBits(64), Is.EqualTo(second));
+        Assert.That(destination.ReadBits(64), Is.EqualTo(third));
+        Assert.That(destination.ReadBits(5), Is.EqualTo(0b1_1011));
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void TestCopyGrowsSmallWriteModeSourceForDeclaredRange(bool unaligned)
+    {
+        using var source = BitPackerPool.Get(new byte[1]);
+        using var destination = BitPackerPool.Get();
+        source.ResetMode(false);
+        source.SetBitPosition(3);
+
+        int bitOrigin = unaligned ? 1 : 0;
+        if (unaligned)
+            destination.WriteBit(true);
+
+        destination.WriteBitDataWithoutConsumingIt(new BitData(source, bitOrigin, 200));
+
+        Assert.That(source.positionInBits, Is.EqualTo(3));
+        Assert.That(source.buffer.Length * 8, Is.GreaterThanOrEqualTo(bitOrigin + 200));
+        Assert.That(destination.positionInBits, Is.EqualTo(200 + (unaligned ? 1 : 0)));
+
+        destination.ResetPositionAndMode(true);
+        if (unaligned)
+            Assert.That(destination.ReadBit(), Is.True);
+        for (int i = 0; i < 200; i++)
+            Assert.That(destination.ReadBit(), Is.False);
+    }
+
+    [Test]
+    public void TestCopyRejectsOutOfRangeReadModeSourceWithoutMovingIt()
+    {
+        using var source = BitPackerPool.Get(new byte[1]);
+        using var destination = BitPackerPool.Get();
+        source.SetBitPosition(3);
+        destination.WriteBit(true);
+
+        Assert.Throws<IndexOutOfRangeException>(() =>
+            destination.WriteBitDataWithoutConsumingIt(new BitData(source, 1, 200)));
+        Assert.That(source.positionInBits, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void TestCopyAcrossAlignmentAndChunkBoundaries()
+    {
+        using var source = BitPackerPool.Get();
+        using var destination = BitPackerPool.Get();
+        var lengths = new[] { 1, 5, 8, 9, 63, 64, 65, 79, 80, 81, 127, 128, 129, 197 };
+
+        for (int i = 0; i < 32; i++)
+            source.WriteBits((ulong)(byte)(i * 37 + 11), 8);
+        int sourcePosition = source.positionInBits;
+
+        for (int sourceOrigin = 0; sourceOrigin < 8; sourceOrigin++)
+        {
+            for (int destinationOffset = 0; destinationOffset < 8; destinationOffset++)
+            {
+                for (int lengthIdx = 0; lengthIdx < lengths.Length; lengthIdx++)
+                {
+                    int length = lengths[lengthIdx];
+                    destination.ResetPositionAndMode(false);
+
+                    for (int i = 0; i < destinationOffset + length + 8; i++)
+                        destination.WriteBit(true);
+                    destination.SetBitPosition(0);
+                    for (int i = 0; i < destinationOffset; i++)
+                        destination.WriteBit((i & 1) == 0);
+                    destination.SetBitPosition(destinationOffset);
+
+                    destination.WriteBitDataWithoutConsumingIt(new BitData(source, sourceOrigin, length));
+
+                    Assert.That(source.positionInBits, Is.EqualTo(sourcePosition));
+                    Assert.That(destination.positionInBits, Is.EqualTo(destinationOffset + length));
+                    destination.ResetPositionAndMode(true);
+                    for (int i = 0; i < destinationOffset; i++)
+                        Assert.That(destination.ReadBit(), Is.EqualTo((i & 1) == 0));
+
+                    source.SetBitPosition(sourceOrigin);
+                    for (int i = 0; i < length; i++)
+                    {
+                        Assert.That(destination.ReadBit(), Is.EqualTo(source.ReadBit()),
+                            $"Mismatch at source origin {sourceOrigin}, destination offset {destinationOffset}, " +
+                            $"length {length}, copied bit {i}.");
+                    }
+                    source.SetBitPosition(sourcePosition);
+
+                    for (int i = 0; i < 8; i++)
+                        Assert.That(destination.ReadBit(), Is.True,
+                            $"Copy overwrote trailing sentinel bit {i} at source origin {sourceOrigin}, " +
+                            $"destination offset {destinationOffset}, length {length}.");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786358348&installation_id=129033668&pr_number=270&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F270&signature=277fbd00ac7111b1de41a136546ffce9f323f4a76ae52a02d15ee7039c44565e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark failure handling with clearer diagnostics, log capture, and cleanup.
  * Added detailed timeout reporting for connection and scenario synchronization.
  * Prevented later scenarios from running after bootstrap or client shutdown failures.
  * Improved bit-level data copying while preserving source state and destination data.
  * Fixed RPC batching behavior across channels, recipients, filters, and packet splits.

* **Performance**
  * Optimized RPC fan-out batching by reusing cached packed data.

* **Tests**
  * Added comprehensive coverage for bit copying, RPC batching, fan-out ordering, filtering, and large recipient sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->