### PR TITLE
feat: fragment unreliable packets

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Broadcast/BroadcastModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Broadcast/BroadcastModule.cs
@@ -8,16 +8,48 @@ using PurrNet.Utils;
 
 namespace PurrNet.Modules
 {
-    public class BroadcastModule : INetworkModule, IDataListener, IPromoteToServerModule
+    public class BroadcastModule : INetworkModule, IDataListener, IConnectionListener, IFixedUpdate,
+        IPromoteToServerModule
     {
         public const int MAX_HEADER_SIZE = 5;
+        const int FRAGMENT_FRAME_PREFIX = 5; // 4-byte type marker + original channel
+        const int FRAGMENT_TIMEOUT_MS = 5000;
+        const int FRAGMENT_CLEANUP_INTERVAL_MS = 500;
+
+        sealed class UnreliableFragmentFrameMarker
+        {
+        }
+
+        static class BroadcastType<T>
+        {
+            public static readonly uint id = ResolveBroadcastTypeId<T>();
+        }
+
+        static readonly uint _fragmentFrameTypeId = Hasher<UnreliableFragmentFrameMarker>.stableHash;
+        static readonly FragmentationLayer.FragmentCallback<FragmentSendState> _sendFragment = SendFragment;
+
         private readonly ITransport _transport;
         private readonly INetworkManager _networkManager;
+        private readonly FragmentationLayer _fragmentation = new FragmentationLayer();
 
         private readonly Dictionary<uint, List<IBroadcastCallback>> _actions =
             new Dictionary<uint, List<IBroadcastCallback>>();
 
         private bool _asServer;
+
+        readonly struct FragmentSendState
+        {
+            public readonly BroadcastModule module;
+            public readonly Connection connection;
+            public readonly Channel channel;
+
+            public FragmentSendState(BroadcastModule module, Connection connection, Channel channel)
+            {
+                this.module = module;
+                this.connection = connection;
+                this.channel = channel;
+            }
+        }
 
         internal event Action<Connection, uint, BitPacker> onRawDataReceived;
 
@@ -34,6 +66,7 @@ namespace PurrNet.Modules
 
         public void Disable(bool asServer)
         {
+            _fragmentation.Reset();
         }
 
         void AssertIsServer(string message)
@@ -45,12 +78,21 @@ namespace PurrNet.Modules
         private static ByteData GetData<T>(T data)
         {
             using var stream = BitPackerPool.Get();
-            var typeId = Hasher.GetStableHashU32<T>();
+            uint typeId = BroadcastType<T>.id;
 
             Packer<uint>.WriteFunc(stream, typeId);
             Packer<T>.WriteFunc(stream, data);
 
             return stream.ToByteData();
+        }
+
+        static uint ResolveBroadcastTypeId<T>()
+        {
+            uint typeId = Hasher.GetStableHashU32<T>();
+            if (typeId == _fragmentFrameTypeId)
+                throw new InvalidOperationException(PurrLogger.FormatMessage(
+                    $"Broadcast type `{typeof(T)}` collides with PurrNet's reserved fragmentation frame id."));
+            return typeId;
         }
 
         static bool ShouldTrackType(Type type)
@@ -86,9 +128,47 @@ namespace PurrNet.Modules
                         $"MTU exceeded by `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}). " +
                         $"Dropping {method} packet.");
                     return false;
+                case MTUExceededBehaviour.Fragment:
+                    int maxMessageSize = FragmentationLayer.GetMaxMessageSize(mtu, FRAGMENT_FRAME_PREFIX);
+                    if (byteData.length > maxMessageSize)
+                    {
+                        PurrLogger.LogError(
+                            $"Cannot fragment `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}). " +
+                            $"Maximum unreliable message size is {maxMessageSize} bytes. Dropping packet.");
+                        return false;
+                    }
+
+                    try
+                    {
+                        var state = new FragmentSendState(this, conn, method);
+                        _fragmentation.Send(byteData, mtu, FRAGMENT_FRAME_PREFIX, state, _sendFragment);
+                    }
+                    catch (ArgumentException e)
+                    {
+                        PurrLogger.LogError(
+                            $"Cannot fragment `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}): {e.Message}");
+                    }
+                    return false;
                 default:
                     return true;
             }
+        }
+
+        static void SendFragment(ByteData fragment, FragmentSendState state)
+        {
+            byte[] data = fragment.data;
+            int offset = fragment.offset;
+            uint marker = _fragmentFrameTypeId;
+            data[offset] = (byte)marker;
+            data[offset + 1] = (byte)(marker >> 8);
+            data[offset + 2] = (byte)(marker >> 16);
+            data[offset + 3] = (byte)(marker >> 24);
+            data[offset + 4] = (byte)state.channel;
+
+            if (state.module._asServer)
+                state.module._transport.SendToClient(state.connection, fragment, state.channel);
+            else
+                state.module._transport.SendToServer(fragment, state.channel);
         }
 
         public void SendToAll<T>(T data, Channel method = Channel.ReliableOrdered)
@@ -177,8 +257,29 @@ namespace PurrNet.Modules
                 if (_asServer != asServer)
                     return;
 
-                using var stream = BitPackerPool.Get(data);
-                var typeId = Packer<uint>.Read(stream);
+                ProcessData(conn, data);
+            }
+            catch (Exception e)
+            {
+                PurrLogger.LogException(e);
+            }
+        }
+
+        void ProcessData(Connection conn, ByteData data)
+        {
+            if (data.length < sizeof(uint))
+                return;
+
+            uint typeId = ReadUInt32(data.data, data.offset);
+            if (typeId == _fragmentFrameTypeId)
+            {
+                ProcessFragment(conn, data);
+                return;
+            }
+
+            using (var stream = BitPackerPool.Get(data))
+            {
+                stream.SkipBits(sizeof(uint) * 8);
 
                 if (!Hasher.TryGetType(typeId, out var typeInfo))
                 {
@@ -194,15 +295,52 @@ namespace PurrNet.Modules
                     Statistics.ReceivedBroadcast(typeInfo, data.segment);
 #endif
             }
-            catch (Exception e)
-            {
-                PurrLogger.LogException(e);
-            }
+        }
+
+        static uint ReadUInt32(byte[] data, int offset)
+        {
+            return data[offset] |
+                   ((uint)data[offset + 1] << 8) |
+                   ((uint)data[offset + 2] << 16) |
+                   ((uint)data[offset + 3] << 24);
+        }
+
+        void ProcessFragment(Connection conn, ByteData data)
+        {
+            if (data.length <= FRAGMENT_FRAME_PREFIX)
+                return;
+
+            var channel = (Channel)data.data[data.offset + 4];
+            if (!IsUnreliable(channel))
+                return;
+
+            var fragment = new ByteData(data.data, data.offset + FRAGMENT_FRAME_PREFIX,
+                data.length - FRAGMENT_FRAME_PREFIX);
+            bool sequenced = channel == Channel.UnreliableSequenced;
+            if (_fragmentation.Receive(conn.connectionId, (byte)channel, sequenced, fragment, out var assembled))
+                ProcessData(conn, assembled);
+        }
+
+        public void FixedUpdate()
+        {
+            _fragmentation.CleanupStaleIfDue(FRAGMENT_TIMEOUT_MS, FRAGMENT_CLEANUP_INTERVAL_MS);
+        }
+
+        public void OnConnected(Connection conn, bool asServer)
+        {
+            if (_asServer == asServer)
+                _fragmentation.RemoveSender(conn.connectionId);
+        }
+
+        public void OnDisconnected(Connection conn, bool asServer)
+        {
+            if (_asServer == asServer)
+                _fragmentation.RemoveSender(conn.connectionId);
         }
 
         public void Subscribe<T>(BroadcastDelegate<T> callback)
         {
-            var hash = Hasher.GetStableHashU32(typeof(T));
+            uint hash = BroadcastType<T>.id;
 
             if (_actions.TryGetValue(hash, out var actions))
             {
@@ -218,7 +356,7 @@ namespace PurrNet.Modules
 
         public void Unsubscribe<T>(BroadcastDelegate<T> callback)
         {
-            var hash = Hasher.GetStableHashU32(typeof(T));
+            uint hash = BroadcastType<T>.id;
             if (!_actions.TryGetValue(hash, out var actions))
                 return;
 
@@ -252,6 +390,7 @@ namespace PurrNet.Modules
 
         public void PromoteToServerModule()
         {
+            _fragmentation.Reset();
             _asServer = true;
         }
 

--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -83,7 +83,7 @@ namespace PurrNet
 
         [Tooltip("What to do when a packet exceeds the MTU on an unreliable channel.")]
         [SerializeField]
-        private MTUExceededBehaviour _mtuExceededBehaviour = MTUExceededBehaviour.Drop;
+        private MTUExceededBehaviour _mtuExceededBehaviour = MTUExceededBehaviour.Fragment;
 
         [SerializeField, UsedImplicitly] private bool _patchLingeringProcessBug;
 

--- a/Assets/PurrNet/Runtime/Managers/RawNetManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/RawNetManager.cs
@@ -31,7 +31,7 @@ namespace PurrNet
 
         [Tooltip("What to do when a packet exceeds the MTU on an unreliable channel.")]
         [SerializeField]
-        private MTUExceededBehaviour _mtuExceededBehaviour = MTUExceededBehaviour.Drop;
+        private MTUExceededBehaviour _mtuExceededBehaviour = MTUExceededBehaviour.Fragment;
 
         private ModulesCollection _serverModules;
         private ModulesCollection _clientModules;

--- a/Assets/PurrNet/Runtime/Pooling/DisposableArray.cs
+++ b/Assets/PurrNet/Runtime/Pooling/DisposableArray.cs
@@ -108,6 +108,26 @@ namespace PurrNet.Pooling
             return result;
         }
 
+        /// <summary>
+        /// Rents an array without clearing value-type contents. The caller must overwrite every
+        /// element that can become observable before reading or exposing the array.
+        /// </summary>
+        internal static DisposableArray<T> CreateUninitialized(int size)
+        {
+            var rented = ArrayPool<T>.Shared.Rent(size);
+#if UNITY_EDITOR && PURR_LEAKS_CHECK
+            AllocationTracker.Track(rented);
+#endif
+            var result = new DisposableArray<T>
+            {
+                array = rented,
+                Count = size,
+                _shouldDispose = true
+            };
+            result._lease = DisposableLeasePool.Rent(out result._leaseVersion);
+            return result;
+        }
+
         public static DisposableArray<T> Create(DisposableArray<T> copyFrom)
         {
             var array = ArrayPool<T>.Shared.Rent(copyFrom.Count);

--- a/Assets/PurrNet/Runtime/Transports/FragmentationLayer.cs
+++ b/Assets/PurrNet/Runtime/Transports/FragmentationLayer.cs
@@ -1,106 +1,514 @@
 using System;
-using System.Buffers;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using PurrNet.Pooling;
 
 namespace PurrNet.Transports
 {
     /// <summary>
-    /// Modular, GC-free fragmentation layer for transports that don't handle fragmentation natively.
-    /// Splits outgoing messages into MTU-sized fragments and reassembles incoming fragments.
-    ///
-    /// Hot path (unfragmented messages) reuses pooled byte buffers after first growth.
-    /// Uses pooled byte buffers for fragment reassembly.
+    /// Allocation-free-on-the-hot-path message fragmentation and bounded reassembly.
+    /// Fragment loss is never recovered here: an incomplete message expires as a unit.
     ///
     /// Header format:
     ///   Unfragmented: [1 byte: 0x00] [payload]
-    ///   Fragmented:   [1 byte: 0x01] [2 bytes: messageId] [1 byte: fragmentIndex] [1 byte: totalFragments] [payload]
+    ///   Fragmented:   [1 byte: 0x01] [4 bytes: messageId] [4 bytes: totalLength]
+    ///                 [2 bytes: fragmentStride] [1 byte: fragmentIndex]
+    ///                 [1 byte: totalFragments] [payload]
     /// </summary>
-    public class FragmentationLayer : IDisposable
+    public sealed class FragmentationLayer : IDisposable
     {
-        /// <summary>Header overhead for unfragmented messages (1 byte).</summary>
+        public delegate void FragmentCallback<TState>(ByteData fragment, TState state);
+
+        /// <summary>Header overhead for unfragmented messages.</summary>
         public const int UNFRAGMENTED_OVERHEAD = 1;
 
-        /// <summary>Header overhead per fragment (5 bytes).</summary>
-        public const int FRAGMENT_OVERHEAD = 5;
+        /// <summary>Header overhead per fragmented message packet.</summary>
+        public const int FRAGMENT_OVERHEAD = 13;
 
-        /// <summary>Maximum number of fragments per message.</summary>
-        public const int MAX_FRAGMENTS = 255;
+        public const int MAX_FRAGMENTS = byte.MaxValue;
+        public const int MAX_MESSAGE_SIZE = 1024 * 1024;
+
+        // Reassembly is exposed to the network and must be bounded independently of expiry.
+        const int MAX_PENDING_MESSAGES = 128;
+        const int MAX_PENDING_MESSAGES_PER_SENDER = 16;
+        const int MAX_PENDING_BYTES = 8 * 1024 * 1024;
+        const int MAX_PENDING_BYTES_PER_SENDER = 2 * 1024 * 1024;
 
         const byte FLAG_UNFRAGMENTED = 0;
         const byte FLAG_FRAGMENTED = 1;
 
-        ushort _nextMessageId;
-        readonly Dictionary<ushort, ReassemblyEntry> _pending = new();
+        static readonly FragmentCallback<Action<ByteData>> _invokeAction = InvokeAction;
+
+        uint _nextMessageId;
+        int _pendingBytes;
+        int _nextCleanupAt;
+        bool _cleanupScheduled;
+
+        readonly Dictionary<ReassemblyKey, ReassemblyEntry> _pending = new(MAX_PENDING_MESSAGES);
+        readonly Dictionary<int, SenderBudget> _senderBudgets = new(MAX_PENDING_MESSAGES);
+        readonly Dictionary<StreamKey, uint> _latestSequencedMessages = new(MAX_PENDING_MESSAGES);
+        readonly List<ReassemblyKey> _removeBuffer = new(MAX_PENDING_MESSAGES);
+        readonly List<StreamKey> _streamRemoveBuffer = new(MAX_PENDING_MESSAGES);
+
         DisposableArray<byte> _sendBuffer;
-        DisposableArray<byte> _assemblyBuffer;
-        readonly List<ushort> _removeBuffer = new();
+        DisposableArray<byte> _completedBuffer;
+
+        readonly struct ReassemblyKey : IEquatable<ReassemblyKey>
+        {
+            public readonly int senderId;
+            public readonly byte streamId;
+            public readonly uint messageId;
+
+            public ReassemblyKey(int senderId, byte streamId, uint messageId)
+            {
+                this.senderId = senderId;
+                this.streamId = streamId;
+                this.messageId = messageId;
+            }
+
+            public bool Equals(ReassemblyKey other) => senderId == other.senderId &&
+                                                        streamId == other.streamId &&
+                                                        messageId == other.messageId;
+
+            public override bool Equals(object obj) => obj is ReassemblyKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hash = senderId;
+                    hash = (hash * 397) ^ streamId;
+                    return (hash * 397) ^ (int)messageId;
+                }
+            }
+        }
+
+        readonly struct StreamKey : IEquatable<StreamKey>
+        {
+            public readonly int senderId;
+            public readonly byte streamId;
+
+            public StreamKey(int senderId, byte streamId)
+            {
+                this.senderId = senderId;
+                this.streamId = streamId;
+            }
+
+            public bool Equals(StreamKey other) => senderId == other.senderId && streamId == other.streamId;
+            public override bool Equals(object obj) => obj is StreamKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (senderId * 397) ^ streamId;
+                }
+            }
+        }
+
+        struct SenderBudget
+        {
+            public int messageCount;
+            public int byteCount;
+        }
 
         struct ReassemblyEntry
         {
             public byte totalFragments;
             public byte receivedCount;
+            public ushort fragmentStride;
             public int totalLength;
-            public DisposableArray<byte>[] fragments;
             public int createdAtTick;
+            public DisposableArray<byte> buffer;
+
+            // 255 flags without allocating a second array for every pending message.
+            ulong _received0;
+            ulong _received1;
+            ulong _received2;
+            ulong _received3;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool TryMarkReceived(byte index)
+            {
+                int word = index >> 6;
+                ulong bit = 1UL << (index & 63);
+
+                switch (word)
+                {
+                    case 0:
+                        if ((_received0 & bit) != 0) return false;
+                        _received0 |= bit;
+                        return true;
+                    case 1:
+                        if ((_received1 & bit) != 0) return false;
+                        _received1 |= bit;
+                        return true;
+                    case 2:
+                        if ((_received2 & bit) != 0) return false;
+                        _received2 |= bit;
+                        return true;
+                    default:
+                        if ((_received3 & bit) != 0) return false;
+                        _received3 |= bit;
+                        return true;
+                }
+            }
         }
 
-        /// <summary>
-        /// Returns the maximum message size that can be sent with the given MTU.
-        /// </summary>
-        public static int GetMaxMessageSize(int mtu)
+        internal int pendingCount => _pending.Count;
+        internal int pendingBytes => _pendingBytes;
+
+        /// <summary>Returns the largest message accepted for the supplied packet size.</summary>
+        public static int GetMaxMessageSize(int mtu, int reservedPrefix = 0)
         {
-            return (mtu - FRAGMENT_OVERHEAD) * MAX_FRAGMENTS;
+            int maxPayload = mtu - reservedPrefix - FRAGMENT_OVERHEAD;
+            if (maxPayload <= 0)
+                return 0;
+
+            maxPayload = Math.Min(maxPayload, ushort.MaxValue);
+            long result = (long)maxPayload * MAX_FRAGMENTS;
+            return (int)Math.Min(result, MAX_MESSAGE_SIZE);
         }
 
         /// <summary>
-        /// Sends data, fragmenting if it exceeds the MTU.
-        /// Calls <paramref name="sendFragment"/> for each fragment (or once for small messages).
-        /// The ByteData passed to the callback is only valid during the callback.
-        /// Cache the delegate to avoid GC allocations.
+        /// Sends a message with no prefix reserved for the caller.
         /// </summary>
         public void Send(ByteData data, int mtu, Action<ByteData> sendFragment)
         {
-            if (data.length + UNFRAGMENTED_OVERHEAD <= mtu)
+            if (sendFragment == null)
+                throw new ArgumentNullException(nameof(sendFragment));
+
+            Send(data, mtu, 0, sendFragment, _invokeAction);
+        }
+
+        /// <summary>
+        /// Splits a message into packets no larger than <paramref name="mtu"/>. The caller may
+        /// reserve bytes at the front of every packet for its own framing and must overwrite all
+        /// reserved bytes in the callback. Buffers passed to the callback are reused and are only
+        /// valid for the duration of the callback.
+        /// </summary>
+        public void Send<TState>(ByteData data, int mtu, int reservedPrefix, TState state,
+            FragmentCallback<TState> sendFragment)
+        {
+            if (sendFragment == null)
+                throw new ArgumentNullException(nameof(sendFragment));
+            if (reservedPrefix < 0)
+                throw new ArgumentOutOfRangeException(nameof(reservedPrefix));
+
+            if (data.length + reservedPrefix + UNFRAGMENTED_OVERHEAD <= mtu)
             {
-                int packetLength = UNFRAGMENTED_OVERHEAD + data.length;
+                int packetLength = reservedPrefix + UNFRAGMENTED_OVERHEAD + data.length;
                 EnsureBuffer(ref _sendBuffer, packetLength);
-                _sendBuffer.array[0] = FLAG_UNFRAGMENTED;
-                Buffer.BlockCopy(data.data, data.offset, _sendBuffer.array, UNFRAGMENTED_OVERHEAD, data.length);
-                sendFragment(new ByteData(_sendBuffer.array, 0, packetLength));
+                _sendBuffer.array[reservedPrefix] = FLAG_UNFRAGMENTED;
+                Buffer.BlockCopy(data.data, data.offset, _sendBuffer.array,
+                    reservedPrefix + UNFRAGMENTED_OVERHEAD, data.length);
+                sendFragment(new ByteData(_sendBuffer.array, 0, packetLength), state);
                 return;
             }
 
-            int maxPayload = mtu - FRAGMENT_OVERHEAD;
-
-            if (maxPayload <= 0)
+            int availablePayload = mtu - reservedPrefix - FRAGMENT_OVERHEAD;
+            if (availablePayload <= 0)
                 throw new ArgumentException(
-                    $"MTU {mtu} is too small for the fragment header ({FRAGMENT_OVERHEAD} bytes).");
+                    $"MTU {mtu} is too small for {reservedPrefix} reserved bytes and the " +
+                    $"{FRAGMENT_OVERHEAD}-byte fragmentation header.", nameof(mtu));
 
-            int totalFragments = (data.length + maxPayload - 1) / maxPayload;
+            int fragmentStride = Math.Min(availablePayload, ushort.MaxValue);
+            int totalFragments = (data.length + fragmentStride - 1) / fragmentStride;
 
-            if (totalFragments > MAX_FRAGMENTS)
+            if (data.length > MAX_MESSAGE_SIZE || totalFragments > MAX_FRAGMENTS)
                 throw new ArgumentException(
                     $"Data ({data.length} bytes) exceeds max fragmentable size for MTU {mtu}. " +
-                    $"Max: {GetMaxMessageSize(mtu)} bytes.");
+                    $"Max: {GetMaxMessageSize(mtu, reservedPrefix)} bytes.", nameof(data));
 
-            var msgId = _nextMessageId++;
+            uint messageId = _nextMessageId++;
 
             for (int i = 0; i < totalFragments; i++)
             {
-                int payloadOffset = i * maxPayload;
-                int payloadLen = Math.Min(maxPayload, data.length - payloadOffset);
-                int packetLength = FRAGMENT_OVERHEAD + payloadLen;
+                int payloadOffset = i * fragmentStride;
+                int payloadLength = Math.Min(fragmentStride, data.length - payloadOffset);
+                int packetLength = reservedPrefix + FRAGMENT_OVERHEAD + payloadLength;
 
                 EnsureBuffer(ref _sendBuffer, packetLength);
-                _sendBuffer.array[0] = FLAG_FRAGMENTED;
-                _sendBuffer.array[1] = (byte)(msgId & 0xFF);
-                _sendBuffer.array[2] = (byte)(msgId >> 8);
-                _sendBuffer.array[3] = (byte)i;
-                _sendBuffer.array[4] = (byte)totalFragments;
-                Buffer.BlockCopy(data.data, data.offset + payloadOffset, _sendBuffer.array, FRAGMENT_OVERHEAD, payloadLen);
-                sendFragment(new ByteData(_sendBuffer.array, 0, packetLength));
+                byte[] packet = _sendBuffer.array;
+                int header = reservedPrefix;
+                packet[header] = FLAG_FRAGMENTED;
+                WriteUInt32(packet, header + 1, messageId);
+                WriteInt32(packet, header + 5, data.length);
+                WriteUInt16(packet, header + 9, (ushort)fragmentStride);
+                packet[header + 11] = (byte)i;
+                packet[header + 12] = (byte)totalFragments;
+
+                Buffer.BlockCopy(data.data, data.offset + payloadOffset, packet,
+                    reservedPrefix + FRAGMENT_OVERHEAD, payloadLength);
+                sendFragment(new ByteData(packet, 0, packetLength), state);
             }
+        }
+
+        /// <summary>Receives on a single unordered stream.</summary>
+        public bool Receive(ByteData data, out ByteData assembled)
+        {
+            return Receive(0, 0, false, data, out assembled);
+        }
+
+        /// <summary>
+        /// Processes a packet for a sender and logical stream. Sequenced streams discard older
+        /// incomplete messages as soon as a newer fragmented message is observed. Reassembled
+        /// data remains valid until the next completed reassembly, <see cref="Reset"/>, or disposal.
+        /// </summary>
+        public bool Receive(int senderId, byte streamId, bool sequenced, ByteData data, out ByteData assembled)
+        {
+            assembled = default;
+
+            if (data.length < UNFRAGMENTED_OVERHEAD)
+                return false;
+
+            int header = data.offset;
+            byte flag = data.data[header];
+
+            if (flag == FLAG_UNFRAGMENTED)
+            {
+                assembled = new ByteData(data.data, header + UNFRAGMENTED_OVERHEAD,
+                    data.length - UNFRAGMENTED_OVERHEAD);
+                return true;
+            }
+
+            if (flag != FLAG_FRAGMENTED || data.length < FRAGMENT_OVERHEAD)
+                return false;
+
+            uint messageId = ReadUInt32(data.data, header + 1);
+            int totalLength = ReadInt32(data.data, header + 5);
+            ushort fragmentStride = ReadUInt16(data.data, header + 9);
+            byte fragmentIndex = data.data[header + 11];
+            byte totalFragments = data.data[header + 12];
+            int payloadLength = data.length - FRAGMENT_OVERHEAD;
+
+            if (!ValidateFragment(totalLength, fragmentStride, fragmentIndex, totalFragments, payloadLength))
+                return false;
+
+            var key = new ReassemblyKey(senderId, streamId, messageId);
+            bool hasEntry = _pending.TryGetValue(key, out var entry);
+
+            if (sequenced && !AcceptSequenced(key, hasEntry))
+                return false;
+
+            if (!hasEntry)
+            {
+                if (!TryReserve(senderId, totalLength))
+                    return false;
+
+                entry = new ReassemblyEntry
+                {
+                    totalFragments = totalFragments,
+                    fragmentStride = fragmentStride,
+                    totalLength = totalLength,
+                    createdAtTick = Environment.TickCount,
+                    // Every range is validated and copied exactly once before completion.
+                    buffer = DisposableArray<byte>.CreateUninitialized(totalLength)
+                };
+            }
+            else if (entry.totalFragments != totalFragments ||
+                     entry.fragmentStride != fragmentStride ||
+                     entry.totalLength != totalLength)
+            {
+                return false;
+            }
+
+            if (!entry.TryMarkReceived(fragmentIndex))
+                return false;
+
+            int destinationOffset = fragmentIndex * fragmentStride;
+            Buffer.BlockCopy(data.data, header + FRAGMENT_OVERHEAD, entry.buffer.array,
+                destinationOffset, payloadLength);
+            entry.receivedCount++;
+
+            if (entry.receivedCount < entry.totalFragments)
+            {
+                _pending[key] = entry;
+                return false;
+            }
+
+            _completedBuffer.Dispose();
+            _completedBuffer = entry.buffer;
+            entry.buffer = default;
+            _pending.Remove(key);
+            Release(senderId, totalLength);
+
+            assembled = new ByteData(_completedBuffer.array, 0, totalLength);
+            return true;
+        }
+
+        /// <summary>Runs stale cleanup at most once per interval.</summary>
+        public void CleanupStaleIfDue(int maxAgeMs, int intervalMs)
+        {
+            if (_pending.Count == 0)
+                return;
+
+            int now = Environment.TickCount;
+            if (_cleanupScheduled && unchecked(now - _nextCleanupAt) < 0)
+                return;
+
+            _nextCleanupAt = unchecked(now + Math.Max(1, intervalMs));
+            _cleanupScheduled = true;
+            CleanupStale(maxAgeMs, now);
+        }
+
+        /// <summary>Removes incomplete messages at least <paramref name="maxAgeMs"/> old.</summary>
+        public void CleanupStale(int maxAgeMs)
+        {
+            CleanupStale(maxAgeMs, Environment.TickCount);
+        }
+
+        public void RemoveSender(int senderId)
+        {
+            _removeBuffer.Clear();
+            foreach (var pair in _pending)
+            {
+                if (pair.Key.senderId == senderId)
+                    _removeBuffer.Add(pair.Key);
+            }
+
+            RemoveBufferedEntries();
+
+            _streamRemoveBuffer.Clear();
+            foreach (var pair in _latestSequencedMessages)
+            {
+                if (pair.Key.senderId == senderId)
+                    _streamRemoveBuffer.Add(pair.Key);
+            }
+
+            for (int i = 0; i < _streamRemoveBuffer.Count; i++)
+                _latestSequencedMessages.Remove(_streamRemoveBuffer[i]);
+        }
+
+        public void Reset()
+        {
+            foreach (var pair in _pending)
+            {
+                var entry = pair.Value;
+                entry.buffer.Dispose();
+            }
+
+            _pending.Clear();
+            _senderBudgets.Clear();
+            _latestSequencedMessages.Clear();
+            _removeBuffer.Clear();
+            _streamRemoveBuffer.Clear();
+            _pendingBytes = 0;
+            _nextCleanupAt = 0;
+            _cleanupScheduled = false;
+
+            _completedBuffer.Dispose();
+            _completedBuffer = default;
+            _sendBuffer.Dispose();
+            _sendBuffer = default;
+        }
+
+        public void Dispose() => Reset();
+
+        bool AcceptSequenced(ReassemblyKey key, bool hasEntry)
+        {
+            var stream = new StreamKey(key.senderId, key.streamId);
+            if (!_latestSequencedMessages.TryGetValue(stream, out uint latest))
+            {
+                _latestSequencedMessages.Add(stream, key.messageId);
+                return true;
+            }
+
+            int relative = unchecked((int)(key.messageId - latest));
+            if (relative < 0)
+                return false;
+
+            if (relative == 0)
+                return hasEntry;
+
+            DiscardStream(stream);
+            _latestSequencedMessages[stream] = key.messageId;
+            return true;
+        }
+
+        void DiscardStream(StreamKey stream)
+        {
+            _removeBuffer.Clear();
+            foreach (var pair in _pending)
+            {
+                if (pair.Key.senderId == stream.senderId && pair.Key.streamId == stream.streamId)
+                    _removeBuffer.Add(pair.Key);
+            }
+
+            RemoveBufferedEntries();
+        }
+
+        bool TryReserve(int senderId, int byteCount)
+        {
+            if (_pending.Count >= MAX_PENDING_MESSAGES || byteCount > MAX_PENDING_BYTES - _pendingBytes)
+                return false;
+
+            _senderBudgets.TryGetValue(senderId, out var budget);
+            if (budget.messageCount >= MAX_PENDING_MESSAGES_PER_SENDER ||
+                byteCount > MAX_PENDING_BYTES_PER_SENDER - budget.byteCount)
+                return false;
+
+            budget.messageCount++;
+            budget.byteCount += byteCount;
+            _senderBudgets[senderId] = budget;
+            _pendingBytes += byteCount;
+            return true;
+        }
+
+        void Release(int senderId, int byteCount)
+        {
+            _pendingBytes -= byteCount;
+            if (!_senderBudgets.TryGetValue(senderId, out var budget))
+                return;
+
+            budget.messageCount--;
+            budget.byteCount -= byteCount;
+            if (budget.messageCount <= 0)
+                _senderBudgets.Remove(senderId);
+            else
+                _senderBudgets[senderId] = budget;
+        }
+
+        void CleanupStale(int maxAgeMs, int now)
+        {
+            _removeBuffer.Clear();
+            foreach (var pair in _pending)
+            {
+                int elapsed = unchecked(now - pair.Value.createdAtTick);
+                if (elapsed < 0 || elapsed >= maxAgeMs)
+                    _removeBuffer.Add(pair.Key);
+            }
+
+            RemoveBufferedEntries();
+        }
+
+        void RemoveBufferedEntries()
+        {
+            for (int i = 0; i < _removeBuffer.Count; i++)
+            {
+                var key = _removeBuffer[i];
+                if (!_pending.TryGetValue(key, out var entry))
+                    continue;
+
+                entry.buffer.Dispose();
+                _pending.Remove(key);
+                Release(key.senderId, entry.totalLength);
+            }
+        }
+
+        static bool ValidateFragment(int totalLength, ushort stride, byte index, byte count, int payloadLength)
+        {
+            if (totalLength <= 0 || totalLength > MAX_MESSAGE_SIZE || stride == 0 ||
+                count == 0 || index >= count)
+                return false;
+
+            int expectedCount = (totalLength + stride - 1) / stride;
+            if (expectedCount != count)
+                return false;
+
+            int offset = index * stride;
+            int expectedPayload = Math.Min(stride, totalLength - offset);
+            return expectedPayload > 0 && payloadLength == expectedPayload;
         }
 
         static void EnsureBuffer(ref DisposableArray<byte> buffer, int size)
@@ -109,168 +517,46 @@ namespace PurrNet.Transports
                 return;
 
             buffer.Dispose();
-            buffer = DisposableArray<byte>.Create(size);
+            buffer = DisposableArray<byte>.CreateUninitialized(size);
         }
 
-        /// <summary>
-        /// Processes a received fragment. Returns true when a complete message is ready.
-        /// For unfragmented messages, <paramref name="assembled"/> is a zero-copy slice of the input.
-        /// For reassembled messages, <paramref name="assembled"/> references an internal buffer
-        /// valid until the next successful reassembly, <see cref="Reset"/>, or <see cref="Dispose"/>.
-        /// </summary>
-        public bool Receive(ByteData data, out ByteData assembled)
+        static void InvokeAction(ByteData data, Action<ByteData> callback) => callback(data);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void WriteUInt16(byte[] data, int offset, ushort value)
         {
-            if (data.length < UNFRAGMENTED_OVERHEAD)
-            {
-                assembled = default;
-                return false;
-            }
-
-            byte flag = data.data[data.offset];
-
-            if (flag == FLAG_UNFRAGMENTED)
-            {
-                assembled = new ByteData(data.data,
-                    data.offset + UNFRAGMENTED_OVERHEAD,
-                    data.length - UNFRAGMENTED_OVERHEAD);
-                return true;
-            }
-
-            if (data.length < FRAGMENT_OVERHEAD)
-            {
-                assembled = default;
-                return false;
-            }
-
-            ushort msgId = (ushort)(data.data[data.offset + 1] | (data.data[data.offset + 2] << 8));
-            byte fragIdx = data.data[data.offset + 3];
-            byte totalFrags = data.data[data.offset + 4];
-
-            if (totalFrags == 0 || fragIdx >= totalFrags)
-            {
-                assembled = default;
-                return false;
-            }
-
-            if (!_pending.TryGetValue(msgId, out var entry))
-            {
-                var fragments = ArrayPool<DisposableArray<byte>>.Shared.Rent(totalFrags);
-                Array.Clear(fragments, 0, totalFrags);
-
-                entry = new ReassemblyEntry
-                {
-                    totalFragments = totalFrags,
-                    receivedCount = 0,
-                    totalLength = 0,
-                    fragments = fragments,
-                    createdAtTick = Environment.TickCount
-                };
-            }
-            else if (entry.totalFragments != totalFrags || !entry.fragments[fragIdx].isDisposed)
-            {
-                assembled = default;
-                return false;
-            }
-
-            int payloadLength = data.length - FRAGMENT_OVERHEAD;
-            var payload = DisposableArray<byte>.Create(payloadLength);
-            Buffer.BlockCopy(data.data, data.offset + FRAGMENT_OVERHEAD, payload.array, 0, payloadLength);
-
-            entry.fragments[fragIdx] = payload;
-            entry.receivedCount++;
-            entry.totalLength += payloadLength;
-            _pending[msgId] = entry;
-
-            if (entry.receivedCount < entry.totalFragments)
-            {
-                assembled = default;
-                return false;
-            }
-
-            EnsureBuffer(ref _assemblyBuffer, entry.totalLength);
-
-            int offset = 0;
-            for (int i = 0; i < entry.totalFragments; i++)
-            {
-                var fragmentPayload = entry.fragments[i];
-                Buffer.BlockCopy(fragmentPayload.array, 0, _assemblyBuffer.array, offset, fragmentPayload.Count);
-                offset += fragmentPayload.Count;
-                fragmentPayload.Dispose();
-                entry.fragments[i] = default;
-            }
-
-            _pending.Remove(msgId);
-            ArrayPool<DisposableArray<byte>>.Shared.Return(entry.fragments, true);
-            assembled = new ByteData(_assemblyBuffer.array, 0, entry.totalLength);
-            return true;
+            data[offset] = (byte)value;
+            data[offset + 1] = (byte)(value >> 8);
         }
 
-        /// <summary>
-        /// Removes reassembly entries older than <paramref name="maxAgeMs"/> milliseconds.
-        /// Call periodically to prevent memory buildup from lost fragments.
-        /// </summary>
-        public void CleanupStale(int maxAgeMs)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static ushort ReadUInt16(byte[] data, int offset)
         {
-            int now = Environment.TickCount;
-            _removeBuffer.Clear();
-
-            foreach (var kvp in _pending)
-            {
-                int elapsed = unchecked(now - kvp.Value.createdAtTick);
-                if (elapsed < 0 || elapsed > maxAgeMs)
-                    _removeBuffer.Add(kvp.Key);
-            }
-
-            for (int i = 0; i < _removeBuffer.Count; i++)
-            {
-                if (_pending.TryGetValue(_removeBuffer[i], out var entry))
-                {
-                    FreeEntry(ref entry);
-                    _pending.Remove(_removeBuffer[i]);
-                }
-            }
+            return (ushort)(data[offset] | (data[offset + 1] << 8));
         }
 
-        /// <summary>
-        /// Resets all state and returns pooled resources.
-        /// </summary>
-        public void Reset()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void WriteUInt32(byte[] data, int offset, uint value)
         {
-            foreach (var kvp in _pending)
-            {
-                var entry = kvp.Value;
-                FreeEntry(ref entry);
-            }
-            _pending.Clear();
-
-            _assemblyBuffer.Dispose();
-            _assemblyBuffer = default;
-            _sendBuffer.Dispose();
-            _sendBuffer = default;
+            data[offset] = (byte)value;
+            data[offset + 1] = (byte)(value >> 8);
+            data[offset + 2] = (byte)(value >> 16);
+            data[offset + 3] = (byte)(value >> 24);
         }
 
-        public void Dispose()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static uint ReadUInt32(byte[] data, int offset)
         {
-            Reset(); 
+            return data[offset] |
+                   ((uint)data[offset + 1] << 8) |
+                   ((uint)data[offset + 2] << 16) |
+                   ((uint)data[offset + 3] << 24);
         }
 
-        void FreeEntry(ref ReassemblyEntry entry)
-        {
-            if (entry.fragments == null)
-                return;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void WriteInt32(byte[] data, int offset, int value) => WriteUInt32(data, offset, (uint)value);
 
-            for (int i = 0; i < entry.totalFragments; i++)
-            {
-                if (!entry.fragments[i].isDisposed)
-                {
-                    entry.fragments[i].Dispose();
-                    entry.fragments[i] = default;
-                }
-            }
-
-            ArrayPool<DisposableArray<byte>>.Shared.Return(entry.fragments, true);
-            entry.fragments = null;
-            entry.totalLength = 0;
-        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static int ReadInt32(byte[] data, int offset) => (int)ReadUInt32(data, offset);
     }
 }

--- a/Assets/PurrNet/Runtime/Transports/Interface/ITransport.cs
+++ b/Assets/PurrNet/Runtime/Transports/Interface/ITransport.cs
@@ -116,12 +116,18 @@ namespace PurrNet.Transports
         /// Automatically upgrade the channel to ReliableOrdered so the packet is
         /// fragmented and delivered reliably. Logs a warning.
         /// </summary>
-        UpgradeToReliable,
+        UpgradeToReliable = 0,
 
         /// <summary>
         /// Drop the packet and log a warning. Preserves unreliable semantics.
         /// </summary>
-        Drop
+        Drop = 1,
+
+        /// <summary>
+        /// Split the message into unreliable MTU-sized fragments. The message is only
+        /// delivered when every fragment arrives; missing fragments are not retransmitted.
+        /// </summary>
+        Fragment = 2
     }
 
     public enum Channel : byte

--- a/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
@@ -252,7 +252,7 @@ public class BitPackerEdgeCaseTests
         sourcePacker.Dispose();
 
         var fragments = new List<byte[]>();
-        layer.Send(source, 13, fragment => Capture(fragment, fragments));
+        layer.Send(source, 24, fragment => Capture(fragment, fragments));
 
         Assert.Greater(fragments.Count, 1);
 
@@ -277,7 +277,7 @@ public class BitPackerEdgeCaseTests
         var source = new ByteData(payload, 3, 37);
         var fragments = new List<byte[]>();
 
-        layer.Send(source, 13, fragment => Capture(fragment, fragments));
+        layer.Send(source, 24, fragment => Capture(fragment, fragments));
 
         Assert.Greater(fragments.Count, 1);
 
@@ -289,6 +289,286 @@ public class BitPackerEdgeCaseTests
         }
 
         AssertByteDataEquals(source, assembled);
+    }
+
+    [Test]
+    public void FragmentationLayer_MissingFragment_DoesNotDeliverAndCleansUp()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payload = new byte[64];
+        var fragments = new List<byte[]>();
+
+        sender.Send(new ByteData(payload, 0, payload.Length), 24, fragment => Capture(fragment, fragments));
+        Assert.Greater(fragments.Count, 2);
+
+        for (int i = 0; i < fragments.Count; i++)
+        {
+            if (i == 1)
+                continue;
+
+            Assert.IsFalse(receiver.Receive(new ByteData(fragments[i], 0, fragments[i].Length), out _));
+        }
+
+        Assert.AreEqual(1, receiver.pendingCount);
+        Assert.AreEqual(payload.Length, receiver.pendingBytes);
+        receiver.CleanupStale(0);
+        Assert.AreEqual(0, receiver.pendingCount);
+        Assert.AreEqual(0, receiver.pendingBytes);
+    }
+
+    [Test]
+    public void FragmentationLayer_DuplicateFragment_IsIgnored()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payload = new byte[37];
+        var fragments = new List<byte[]>();
+        sender.Send(new ByteData(payload, 0, payload.Length), 24, fragment => Capture(fragment, fragments));
+
+        var first = new ByteData(fragments[0], 0, fragments[0].Length);
+        Assert.IsFalse(receiver.Receive(first, out _));
+        Assert.IsFalse(receiver.Receive(first, out _));
+
+        ByteData assembled = default;
+        for (int i = 1; i < fragments.Count; i++)
+            Assert.AreEqual(i == fragments.Count - 1,
+                receiver.Receive(new ByteData(fragments[i], 0, fragments[i].Length), out assembled));
+
+        AssertByteDataEquals(new ByteData(payload, 0, payload.Length), assembled);
+    }
+
+    [Test]
+    public void FragmentationLayer_SeparatesIdenticalMessageIdsBySender()
+    {
+        using var senderA = new FragmentationLayer();
+        using var senderB = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payloadA = new byte[31];
+        var payloadB = new byte[31];
+        for (int i = 0; i < payloadA.Length; i++)
+        {
+            payloadA[i] = (byte)i;
+            payloadB[i] = (byte)(255 - i);
+        }
+
+        var fragmentsA = new List<byte[]>();
+        var fragmentsB = new List<byte[]>();
+        senderA.Send(new ByteData(payloadA, 0, payloadA.Length), 24, f => Capture(f, fragmentsA));
+        senderB.Send(new ByteData(payloadB, 0, payloadB.Length), 24, f => Capture(f, fragmentsB));
+
+        ByteData assembledA = default;
+        ByteData assembledB = default;
+        for (int i = 0; i < fragmentsA.Count; i++)
+        {
+            bool completedA = receiver.Receive(10, 0, false,
+                new ByteData(fragmentsA[i], 0, fragmentsA[i].Length), out var currentA);
+            if (completedA) assembledA = new ByteData((byte[])currentA.span.ToArray(), 0, currentA.length);
+
+            bool completedB = receiver.Receive(20, 0, false,
+                new ByteData(fragmentsB[i], 0, fragmentsB[i].Length), out var currentB);
+            if (completedB) assembledB = new ByteData((byte[])currentB.span.ToArray(), 0, currentB.length);
+        }
+
+        AssertByteDataEquals(new ByteData(payloadA, 0, payloadA.Length), assembledA);
+        AssertByteDataEquals(new ByteData(payloadB, 0, payloadB.Length), assembledB);
+    }
+
+    [Test]
+    public void FragmentationLayer_SequencedNewerMessageInvalidatesOlderAssembly()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var oldPayload = new byte[35];
+        var newPayload = new byte[35];
+        for (int i = 0; i < newPayload.Length; i++)
+            newPayload[i] = (byte)(i + 100);
+
+        var oldFragments = new List<byte[]>();
+        var newFragments = new List<byte[]>();
+        sender.Send(new ByteData(oldPayload, 0, oldPayload.Length), 24, f => Capture(f, oldFragments));
+        sender.Send(new ByteData(newPayload, 0, newPayload.Length), 24, f => Capture(f, newFragments));
+
+        Assert.IsFalse(receiver.Receive(7, 1, true,
+            new ByteData(oldFragments[0], 0, oldFragments[0].Length), out _));
+        Assert.IsFalse(receiver.Receive(7, 1, true,
+            new ByteData(newFragments[0], 0, newFragments[0].Length), out _));
+
+        for (int i = 1; i < oldFragments.Count; i++)
+            Assert.IsFalse(receiver.Receive(7, 1, true,
+                new ByteData(oldFragments[i], 0, oldFragments[i].Length), out _));
+
+        ByteData assembled = default;
+        for (int i = 1; i < newFragments.Count; i++)
+            Assert.AreEqual(i == newFragments.Count - 1,
+                receiver.Receive(7, 1, true,
+                    new ByteData(newFragments[i], 0, newFragments[i].Length), out assembled));
+
+        AssertByteDataEquals(new ByteData(newPayload, 0, newPayload.Length), assembled);
+        Assert.AreEqual(0, receiver.pendingCount);
+    }
+
+    [Test]
+    public void FragmentationLayer_PerSenderPendingMessagesAreBoundedAndReleasedOnDisconnect()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payload = new byte[37];
+        var fragments = new List<byte[]>();
+
+        for (int message = 0; message < 20; message++)
+        {
+            fragments.Clear();
+            sender.Send(new ByteData(payload, 0, payload.Length), 24, f => Capture(f, fragments));
+            Assert.IsFalse(receiver.Receive(99, 0, false,
+                new ByteData(fragments[0], 0, fragments[0].Length), out _));
+        }
+
+        Assert.AreEqual(16, receiver.pendingCount);
+        Assert.AreEqual(16 * payload.Length, receiver.pendingBytes);
+
+        receiver.RemoveSender(99);
+        Assert.AreEqual(0, receiver.pendingCount);
+        Assert.AreEqual(0, receiver.pendingBytes);
+    }
+
+    [Test]
+    public void FragmentationLayer_GlobalPendingMessageCountIsBoundedAcrossSenders()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payload = new byte[37];
+        var fragments = new List<byte[]>();
+
+        for (int senderId = 0; senderId < 140; senderId++)
+        {
+            fragments.Clear();
+            sender.Send(new ByteData(payload, 0, payload.Length), 24, f => Capture(f, fragments));
+            Assert.IsFalse(receiver.Receive(senderId, 0, false,
+                new ByteData(fragments[0], 0, fragments[0].Length), out _));
+        }
+
+        Assert.AreEqual(128, receiver.pendingCount);
+        Assert.AreEqual(128 * payload.Length, receiver.pendingBytes);
+    }
+
+    [Test]
+    public void FragmentationLayer_MalformedLengthIsRejectedBeforeAllocating()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payload = new byte[37];
+        var fragments = new List<byte[]>();
+        sender.Send(new ByteData(payload, 0, payload.Length), 24, f => Capture(f, fragments));
+
+        byte[] malformed = fragments[0];
+        int invalidLength = FragmentationLayer.MAX_MESSAGE_SIZE + 1;
+        malformed[5] = (byte)invalidLength;
+        malformed[6] = (byte)(invalidLength >> 8);
+        malformed[7] = (byte)(invalidLength >> 16);
+        malformed[8] = (byte)(invalidLength >> 24);
+
+        Assert.IsFalse(receiver.Receive(new ByteData(malformed, 0, malformed.Length), out _));
+        Assert.AreEqual(0, receiver.pendingCount);
+        Assert.AreEqual(0, receiver.pendingBytes);
+    }
+
+    [Test]
+    public void FragmentationLayer_MaximumFragmentCountBoundaryRoundtrips()
+    {
+        const int mtu = 24;
+        int maxLength = FragmentationLayer.GetMaxMessageSize(mtu);
+        var payload = new byte[maxLength];
+        for (int i = 0; i < payload.Length; i++)
+            payload[i] = (byte)(i * 13 + 5);
+
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var fragments = new List<byte[]>();
+        sender.Send(new ByteData(payload, 0, payload.Length), mtu, f => Capture(f, fragments));
+
+        Assert.AreEqual(FragmentationLayer.MAX_FRAGMENTS, fragments.Count);
+        ByteData assembled = default;
+        for (int i = fragments.Count - 1; i >= 0; i--)
+            Assert.AreEqual(i == 0,
+                receiver.Receive(new ByteData(fragments[i], 0, fragments[i].Length), out assembled));
+
+        AssertByteDataEquals(new ByteData(payload, 0, payload.Length), assembled);
+
+        var tooLarge = new byte[maxLength + 1];
+        Assert.Throws<ArgumentException>(() =>
+            sender.Send(new ByteData(tooLarge, 0, tooLarge.Length), mtu, _ => { }));
+    }
+
+    [Test]
+    public void FragmentationLayer_ConcurrentUnorderedMessagesFromOneSenderRemainIndependent()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var payloadA = new byte[41];
+        var payloadB = new byte[41];
+        for (int i = 0; i < payloadA.Length; i++)
+        {
+            payloadA[i] = (byte)(i + 1);
+            payloadB[i] = (byte)(200 - i);
+        }
+
+        var fragmentsA = new List<byte[]>();
+        var fragmentsB = new List<byte[]>();
+        sender.Send(new ByteData(payloadA, 0, payloadA.Length), 24, f => Capture(f, fragmentsA));
+        sender.Send(new ByteData(payloadB, 0, payloadB.Length), 24, f => Capture(f, fragmentsB));
+
+        byte[] assembledA = null;
+        byte[] assembledB = null;
+        for (int i = fragmentsA.Count - 1; i >= 0; i--)
+        {
+            if (receiver.Receive(3, 0, false,
+                    WithOffset(fragmentsA[i], 3), out var currentA))
+                assembledA = currentA.span.ToArray();
+
+            if (receiver.Receive(3, 0, false,
+                    WithOffset(fragmentsB[i], 5), out var currentB))
+                assembledB = currentB.span.ToArray();
+        }
+
+        CollectionAssert.AreEqual(payloadA, assembledA);
+        CollectionAssert.AreEqual(payloadB, assembledB);
+    }
+
+    [Test]
+    public void FragmentationLayer_SequencedMessageIdWrapTreatsZeroAsNewer()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var nextId = typeof(FragmentationLayer).GetField("_nextMessageId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(nextId);
+        nextId.SetValue(sender, uint.MaxValue);
+
+        var oldPayload = new byte[35];
+        var newPayload = new byte[35];
+        for (int i = 0; i < newPayload.Length; i++)
+            newPayload[i] = (byte)(i + 50);
+
+        var oldFragments = new List<byte[]>();
+        var newFragments = new List<byte[]>();
+        sender.Send(new ByteData(oldPayload, 0, oldPayload.Length), 24, f => Capture(f, oldFragments));
+        sender.Send(new ByteData(newPayload, 0, newPayload.Length), 24, f => Capture(f, newFragments));
+
+        Assert.IsFalse(receiver.Receive(1, 1, true,
+            new ByteData(oldFragments[0], 0, oldFragments[0].Length), out _));
+
+        ByteData assembled = default;
+        for (int i = 0; i < newFragments.Count; i++)
+            Assert.AreEqual(i == newFragments.Count - 1,
+                receiver.Receive(1, 1, true,
+                    new ByteData(newFragments[i], 0, newFragments[i].Length), out assembled));
+
+        for (int i = 1; i < oldFragments.Count; i++)
+            Assert.IsFalse(receiver.Receive(1, 1, true,
+                new ByteData(oldFragments[i], 0, oldFragments[i].Length), out _));
+
+        AssertByteDataEquals(new ByteData(newPayload, 0, newPayload.Length), assembled);
     }
 
     [Test]
@@ -358,6 +638,13 @@ public class BitPackerEdgeCaseTests
         Assert.AreEqual(expected.length, actual.length);
         for (int i = 0; i < expected.length; i++)
             Assert.AreEqual(expected.data[expected.offset + i], actual.data[actual.offset + i], $"Byte {i}");
+    }
+
+    private static ByteData WithOffset(byte[] source, int offset)
+    {
+        var wrapped = new byte[source.Length + offset + 2];
+        Buffer.BlockCopy(source, 0, wrapped, offset, source.Length);
+        return new ByteData(wrapped, offset, source.Length);
     }
 
     private static bool RunServerValidators<T>(ValidatedSyncVar<T> syncVar, T oldValue, T newValue)

--- a/Assets/Tests/BitPacker.Tests/BroadcastFragmentationTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BroadcastFragmentationTests.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using NUnit.Framework;
+using PurrNet;
+using PurrNet.Modules;
+using PurrNet.Transports;
+using UnityEngine;
+
+public class BroadcastFragmentationTests
+{
+    sealed class SentPacket
+    {
+        public Connection connection;
+        public Channel channel;
+        public byte[] data;
+    }
+
+    sealed class TestTransport : ITransport
+    {
+        readonly List<Connection> _connections = new List<Connection>();
+
+        public int mtu = 64;
+        public bool capturePackets = true;
+        public int sendCount;
+        public uint checksum;
+        public readonly List<SentPacket> sent = new List<SentPacket>();
+
+#pragma warning disable CS0067
+        public event OnConnected onConnected;
+        public event OnDisconnected onDisconnected;
+        public event OnDataReceived onDataReceived;
+        public event OnDataSent onDataSent;
+        public event OnConnectionState onConnectionState;
+#pragma warning restore CS0067
+
+        public ConnectionState clientState => ConnectionState.Connected;
+        public ConnectionState listenerState => ConnectionState.Connected;
+        public IReadOnlyList<Connection> connections => _connections;
+
+        public int GetMTU(Connection target, Channel channel, bool asServer) => mtu;
+
+        public void SendToClient(Connection target, ByteData data, Channel method = Channel.ReliableOrdered)
+        {
+            Capture(target, data, method);
+        }
+
+        public void SendToServer(ByteData data, Channel method = Channel.ReliableOrdered)
+        {
+            Capture(default, data, method);
+        }
+
+        void Capture(Connection connection, ByteData data, Channel channel)
+        {
+            sendCount++;
+            checksum += data.data[data.offset];
+            checksum += data.data[data.offset + data.length - 1];
+            if (!capturePackets)
+                return;
+
+            var copy = new byte[data.length];
+            Buffer.BlockCopy(data.data, data.offset, copy, 0, data.length);
+            sent.Add(new SentPacket { connection = connection, channel = channel, data = copy });
+        }
+
+        public void Connect(string ip, ushort port) { }
+        public void Disconnect() { }
+        public void Listen(ushort port) { }
+        public void StopListening() { }
+        public void RaiseDataReceived(Connection conn, ByteData data, bool asServer) { }
+        public void RaiseDataSent(Connection conn, ByteData data, bool asServer) { }
+        public void CloseConnection(Connection conn) { }
+        public void ReceiveMessages(float delta) { }
+        public void SendMessages(float delta) { }
+    }
+
+    sealed class TestManager : INetworkManager
+    {
+        public TestManager(ITransport transport, MTUExceededBehaviour behaviour)
+        {
+            rawTransport = transport;
+            mtuExceededBehaviour = behaviour;
+        }
+
+        public bool isOffline => false;
+        public bool isServer => false;
+        public bool isClient => false;
+        public ITransport rawTransport { get; }
+        public MTUExceededBehaviour mtuExceededBehaviour { get; }
+        public ConnectionState serverState => ConnectionState.Connected;
+        public ConnectionState clientState => ConnectionState.Connected;
+        public bool shouldAutoStartServer => false;
+        public bool shouldAutoStartClient => false;
+        public NetworkRules networkRules => null;
+        public void StartServer() { }
+        public void StartClient() { }
+        public void StopServer() { }
+        public void StopClient() { }
+        public void InternalRegisterClientModules() { }
+        public void InternalRegisterServerModules() { }
+        public void InternalUnregisterClientModules() { }
+        public void InternalUnregisterServerModules() { }
+        public bool HasModule<T>(bool asServer) where T : INetworkModule => false;
+    }
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        NetworkManager.CallAllRegisters();
+    }
+
+    [Test]
+    public void MTUExceededBehaviour_PreservesSerializedValues()
+    {
+        Assert.AreEqual(0, (byte)MTUExceededBehaviour.UpgradeToReliable);
+        Assert.AreEqual(1, (byte)MTUExceededBehaviour.Drop);
+        Assert.AreEqual(2, (byte)MTUExceededBehaviour.Fragment);
+    }
+
+    [Test]
+    public void NewRawNetManager_DefaultsToFragmentWithoutChangingLegacyEnumValues()
+    {
+        var gameObject = new GameObject("RawNetManager fragmentation default test");
+        try
+        {
+            var manager = gameObject.AddComponent<RawNetManager>();
+            Assert.AreEqual(MTUExceededBehaviour.Fragment, manager.mtuExceededBehaviour);
+        }
+        finally
+        {
+            UnityEngine.Object.DestroyImmediate(gameObject);
+        }
+    }
+
+    [Test]
+    public void UnreliableOversizeMessage_IsFragmentedWithinMTUAndReassembledOutOfOrder()
+    {
+        var senderTransport = new TestTransport { mtu = 64 };
+        var receiverTransport = new TestTransport { mtu = 64 };
+        var sender = new BroadcastModule(
+            new TestManager(senderTransport, MTUExceededBehaviour.Fragment), true);
+        var receiver = new BroadcastModule(
+            new TestManager(receiverTransport, MTUExceededBehaviour.Fragment), false);
+        var connection = new Connection(42);
+        string expected = CreatePayload(400, 7);
+        string received = null;
+        int receiveCount = 0;
+
+        receiver.Subscribe<string>((_, value, _) =>
+        {
+            received = value;
+            receiveCount++;
+        });
+
+        sender.Send(connection, expected, Channel.Unreliable);
+
+        Assert.Greater(senderTransport.sent.Count, 1);
+        for (int i = 0; i < senderTransport.sent.Count; i++)
+        {
+            Assert.LessOrEqual(senderTransport.sent[i].data.Length, senderTransport.mtu);
+            Assert.AreEqual(Channel.Unreliable, senderTransport.sent[i].channel);
+            Assert.AreEqual(connection, senderTransport.sent[i].connection);
+        }
+
+        for (int i = senderTransport.sent.Count - 1; i >= 0; i--)
+        {
+            byte[] packet = senderTransport.sent[i].data;
+            receiver.OnDataReceived(connection, new ByteData(packet, 0, packet.Length), false);
+        }
+
+        Assert.AreEqual(1, receiveCount);
+        Assert.AreEqual(expected, received);
+    }
+
+    [Test]
+    public void UnreliableSequenced_NewerFragmentedMessageInvalidatesOlderIncompleteMessage()
+    {
+        var transport = new TestTransport { mtu = 64 };
+        var sender = new BroadcastModule(new TestManager(transport, MTUExceededBehaviour.Fragment), true);
+        var receiver = new BroadcastModule(
+            new TestManager(new TestTransport(), MTUExceededBehaviour.Fragment), false);
+        var connection = new Connection(5);
+        string oldValue = CreatePayload(250, 1);
+        string newValue = CreatePayload(250, 2);
+        var received = new List<string>();
+        receiver.Subscribe<string>((_, value, _) => received.Add(value));
+
+        sender.Send(connection, oldValue, Channel.UnreliableSequenced);
+        int oldFragmentCount = transport.sent.Count;
+        sender.Send(connection, newValue, Channel.UnreliableSequenced);
+
+        Assert.Greater(oldFragmentCount, 1);
+        Assert.Greater(transport.sent.Count - oldFragmentCount, 1);
+
+        Deliver(receiver, connection, transport.sent[0]);
+        Deliver(receiver, connection, transport.sent[oldFragmentCount]);
+
+        for (int i = 1; i < oldFragmentCount; i++)
+            Deliver(receiver, connection, transport.sent[i]);
+
+        for (int i = oldFragmentCount + 1; i < transport.sent.Count; i++)
+            Deliver(receiver, connection, transport.sent[i]);
+
+        Assert.AreEqual(1, received.Count);
+        Assert.AreEqual(newValue, received[0]);
+    }
+
+    [Test]
+    public void UnderMTUUnreliableMessage_UsesOriginalSinglePacketPath()
+    {
+        var transport = new TestTransport { mtu = 256 };
+        var sender = new BroadcastModule(new TestManager(transport, MTUExceededBehaviour.Fragment), true);
+        var connection = new Connection(9);
+
+        sender.Send(connection, "small", Channel.Unreliable);
+
+        Assert.AreEqual(1, transport.sent.Count);
+        Assert.AreEqual(Channel.Unreliable, transport.sent[0].channel);
+    }
+
+    [Test]
+    public void BroadcastFragmentation_SteadyStateOversizeSendAllocatesZeroManagedBytes()
+    {
+        const int iterations = 10_000;
+        var transport = new TestTransport { mtu = 64, capturePackets = false };
+        var sender = new BroadcastModule(new TestManager(transport, MTUExceededBehaviour.Fragment), true);
+        var connection = new Connection(12);
+        string payload = CreatePayload(400, 11);
+
+        for (int i = 0; i < 128; i++)
+            sender.Send(connection, payload, Channel.Unreliable);
+
+        transport.sendCount = 0;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.GetAllocatedBytesForCurrentThread();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            sender.Send(connection, payload, Channel.Unreliable);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Greater(transport.sendCount, iterations);
+        Assert.AreEqual(0, allocated, $"Broadcast fragmentation allocated {allocated} managed bytes.");
+    }
+
+    [Test]
+    public void BroadcastUnderMTU_SteadyStateSendAllocatesZeroManagedBytes()
+    {
+        const int iterations = 100_000;
+        var transport = new TestTransport { mtu = 256, capturePackets = false };
+        var sender = new BroadcastModule(new TestManager(transport, MTUExceededBehaviour.Fragment), true);
+        var connection = new Connection(13);
+
+        for (int i = 0; i < 128; i++)
+            sender.Send(connection, 123456, Channel.Unreliable);
+
+        transport.sendCount = 0;
+        GC.GetAllocatedBytesForCurrentThread();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            sender.Send(connection, 123456, Channel.Unreliable);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.AreEqual(iterations, transport.sendCount);
+        Assert.AreEqual(0, allocated, $"Under-MTU broadcast send allocated {allocated} managed bytes.");
+    }
+
+    [Test]
+    public void Benchmark_BroadcastUnderMTUAndFragmentedSend()
+    {
+        const int fastIterations = 250_000;
+        const int fragmentedIterations = 20_000;
+        var connection = new Connection(14);
+
+        var fastTransport = new TestTransport { mtu = 256, capturePackets = false };
+        var fastSender = new BroadcastModule(
+            new TestManager(fastTransport, MTUExceededBehaviour.Fragment), true);
+        var fragmentedTransport = new TestTransport { mtu = 64, capturePackets = false };
+        var fragmentedSender = new BroadcastModule(
+            new TestManager(fragmentedTransport, MTUExceededBehaviour.Fragment), true);
+        string fragmentedPayload = CreatePayload(400, 19);
+
+        for (int i = 0; i < 128; i++)
+        {
+            fastSender.Send(connection, 123456, Channel.Unreliable);
+            fragmentedSender.Send(connection, fragmentedPayload, Channel.Unreliable);
+        }
+
+        fastTransport.sendCount = 0;
+        fragmentedTransport.sendCount = 0;
+        var fastWatch = new Stopwatch();
+        var fragmentedWatch = new Stopwatch();
+
+        long fastBefore = GC.GetAllocatedBytesForCurrentThread();
+        fastWatch.Start();
+        for (int i = 0; i < fastIterations; i++)
+            fastSender.Send(connection, 123456, Channel.Unreliable);
+        fastWatch.Stop();
+        long fastAllocated = GC.GetAllocatedBytesForCurrentThread() - fastBefore;
+
+        long fragmentedBefore = GC.GetAllocatedBytesForCurrentThread();
+        fragmentedWatch.Start();
+        for (int i = 0; i < fragmentedIterations; i++)
+            fragmentedSender.Send(connection, fragmentedPayload, Channel.Unreliable);
+        fragmentedWatch.Stop();
+        long fragmentedAllocated = GC.GetAllocatedBytesForCurrentThread() - fragmentedBefore;
+
+        double fastNs = fastWatch.Elapsed.TotalMilliseconds * 1_000_000.0 / fastIterations;
+        double fragmentedNs = fragmentedWatch.Elapsed.TotalMilliseconds * 1_000_000.0 / fragmentedIterations;
+        double packetsPerMessage = (double)fragmentedTransport.sendCount / fragmentedIterations;
+        UnityEngine.Debug.Log($"[Broadcast Fragmentation] under-MTU={fastNs:F1} ns/message " +
+                              $"managed={fastAllocated} B | fragmented={fragmentedNs:F1} ns/message " +
+                              $"packets/message={packetsPerMessage:F1} managed={fragmentedAllocated} B");
+
+        Assert.AreEqual(fastIterations, fastTransport.sendCount);
+        Assert.Greater(fragmentedTransport.sendCount, fragmentedIterations);
+        Assert.AreEqual(0, fastAllocated);
+        Assert.AreEqual(0, fragmentedAllocated);
+    }
+
+    static void Deliver(BroadcastModule receiver, Connection connection, SentPacket sent)
+    {
+        receiver.OnDataReceived(connection, new ByteData(sent.data, 0, sent.data.Length), false);
+    }
+
+    static string CreatePayload(int length, int seed)
+    {
+        var chars = new char[length];
+        for (int i = 0; i < chars.Length; i++)
+            chars[i] = (char)('!' + ((i * 31 + seed * 17) % 90));
+        return new string(chars);
+    }
+}

--- a/Assets/Tests/BitPacker.Tests/BroadcastFragmentationTests.cs.meta
+++ b/Assets/Tests/BitPacker.Tests/BroadcastFragmentationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04647741b2794ccfafef2efaf837f480

--- a/Assets/Tests/BitPacker.Tests/FragmentationBenchmarks.cs
+++ b/Assets/Tests/BitPacker.Tests/FragmentationBenchmarks.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using NUnit.Framework;
+using PurrNet.Transports;
+using Debug = UnityEngine.Debug;
+
+/// <summary>
+/// Allocation guards and repeatable microbenchmarks for the transport-independent
+/// fragmentation core. Times are diagnostic rather than pass/fail thresholds.
+/// </summary>
+public class FragmentationBenchmarks
+{
+    sealed class LoopbackState
+    {
+        public readonly FragmentationLayer receiver;
+        public int completed;
+        public uint checksum;
+
+        public LoopbackState(FragmentationLayer receiver)
+        {
+            this.receiver = receiver;
+        }
+    }
+
+    sealed class CountState
+    {
+        public int packets;
+    }
+
+    static readonly FragmentationLayer.FragmentCallback<LoopbackState> _loopback = Loopback;
+    static readonly FragmentationLayer.FragmentCallback<CountState> _count = Count;
+
+    [Test]
+    public void Fragmentation_SteadyStateFragmentedRoundtrip_AllocatesZeroManagedBytes()
+    {
+        const int mtu = 256;
+        const int iterations = 10_000;
+        var payload = CreatePayload(1400);
+
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var state = new LoopbackState(receiver);
+
+        for (int i = 0; i < 128; i++)
+            sender.Send(new ByteData(payload, 0, payload.Length), mtu, 0, state, _loopback);
+
+        state.completed = 0;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.GetAllocatedBytesForCurrentThread(); // initialize any runtime bookkeeping
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            sender.Send(new ByteData(payload, 0, payload.Length), mtu, 0, state, _loopback);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.AreEqual(iterations, state.completed);
+        Assert.AreEqual(0, allocated, $"Steady-state fragmentation allocated {allocated} managed bytes.");
+    }
+
+    [Test]
+    public void Fragmentation_SteadyStateUnfragmentedFraming_AllocatesZeroManagedBytes()
+    {
+        const int iterations = 100_000;
+        var payload = CreatePayload(64);
+        using var layer = new FragmentationLayer();
+        var state = new CountState();
+
+        for (int i = 0; i < 128; i++)
+            layer.Send(new ByteData(payload, 0, payload.Length), 1200, 0, state, _count);
+
+        state.packets = 0;
+        GC.GetAllocatedBytesForCurrentThread();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < iterations; i++)
+            layer.Send(new ByteData(payload, 0, payload.Length), 1200, 0, state, _count);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.AreEqual(iterations, state.packets);
+        Assert.AreEqual(0, allocated, $"Steady-state unfragmented framing allocated {allocated} managed bytes.");
+    }
+
+    [Test]
+    [TestCase(256, 64)]
+    [TestCase(1400, 256)]
+    [TestCase(32768, 1200)]
+    public void Benchmark_Fragmentation_InOrderRoundtrip(int payloadSize, int mtu)
+    {
+        var payload = CreatePayload(payloadSize);
+        int iterations = Math.Min(50_000, Math.Max(2_000, 32 * 1024 * 1024 / payloadSize));
+
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var state = new LoopbackState(receiver);
+        for (int i = 0; i < 128; i++)
+            sender.Send(new ByteData(payload, 0, payload.Length), mtu, 0, state, _loopback);
+
+        state.completed = 0;
+        var watch = new Stopwatch();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        watch.Start();
+        for (int i = 0; i < iterations; i++)
+            sender.Send(new ByteData(payload, 0, payload.Length), mtu, 0, state, _loopback);
+        watch.Stop();
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.AreEqual(iterations, state.completed);
+        double nsPerMessage = watch.Elapsed.TotalMilliseconds * 1_000_000.0 / iterations;
+        double mibPerSecond = (double)payloadSize * iterations /
+                              (1024 * 1024 * watch.Elapsed.TotalSeconds);
+        Debug.Log($"[Fragmentation In-Order] payload={payloadSize} MTU={mtu} " +
+                  $"{nsPerMessage:F1} ns/message {mibPerSecond:F1} MiB/s managed={allocated} B");
+    }
+
+    [Test]
+    public void Benchmark_Fragmentation_OutOfOrderReassembly()
+    {
+        const int payloadSize = 1400;
+        const int mtu = 256;
+        const int iterations = 25_000;
+        var payload = CreatePayload(payloadSize);
+        var packets = new List<byte[]>();
+
+        using (var sender = new FragmentationLayer())
+        {
+            sender.Send(new ByteData(payload, 0, payload.Length), mtu, fragment =>
+            {
+                var copy = new byte[fragment.length];
+                Buffer.BlockCopy(fragment.data, fragment.offset, copy, 0, fragment.length);
+                packets.Add(copy);
+            });
+        }
+
+        using var receiver = new FragmentationLayer();
+        int completed = 0;
+        uint checksum = 0;
+
+        void RunOnce()
+        {
+            for (int i = packets.Count - 1; i >= 0; i--)
+            {
+                byte[] packet = packets[i];
+                if (!receiver.Receive(new ByteData(packet, 0, packet.Length), out var assembled))
+                    continue;
+
+                completed++;
+                checksum += assembled.data[assembled.offset];
+                checksum += assembled.data[assembled.offset + assembled.length - 1];
+            }
+        }
+
+        for (int i = 0; i < 128; i++)
+            RunOnce();
+
+        completed = 0;
+        var watch = new Stopwatch();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        watch.Start();
+        for (int i = 0; i < iterations; i++)
+            RunOnce();
+        watch.Stop();
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.AreEqual(iterations, completed);
+        double nsPerMessage = watch.Elapsed.TotalMilliseconds * 1_000_000.0 / iterations;
+        double mibPerSecond = (double)payloadSize * iterations /
+                              (1024 * 1024 * watch.Elapsed.TotalSeconds);
+        Debug.Log($"[Fragmentation Out-of-Order] payload={payloadSize} MTU={mtu} fragments={packets.Count} " +
+                  $"{nsPerMessage:F1} ns/message {mibPerSecond:F1} MiB/s managed={allocated} B checksum={checksum}");
+    }
+
+    static void Loopback(ByteData fragment, LoopbackState state)
+    {
+        if (!state.receiver.Receive(fragment, out var assembled))
+            return;
+
+        state.completed++;
+        state.checksum += assembled.data[assembled.offset];
+        state.checksum += assembled.data[assembled.offset + assembled.length - 1];
+    }
+
+    static void Count(ByteData fragment, CountState state)
+    {
+        state.packets++;
+    }
+
+    static byte[] CreatePayload(int size)
+    {
+        var payload = new byte[size];
+        for (int i = 0; i < payload.Length; i++)
+            payload[i] = (byte)(i * 31 + 17);
+        return payload;
+    }
+}

--- a/Assets/Tests/BitPacker.Tests/FragmentationBenchmarks.cs.meta
+++ b/Assets/Tests/BitPacker.Tests/FragmentationBenchmarks.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6801957485d8495b9e036ac67024a306


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786366038&installation_id=129033668&pr_number=271&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F271&signature=2c1180ada531545f4f74e920e1ba52a23294ca895aef79df8cf2167e6f1a47bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oversized unreliable broadcast messages are now automatically fragmented and reassembled.
  * Fragmented messages support out-of-order delivery, sequencing, duplicate handling, and stale-fragment cleanup.
  * Fragmentation includes safeguards that limit pending memory and message usage.

* **Performance**
  * Improved allocation efficiency for both regular and fragmented broadcasts.

* **Bug Fixes**
  * Prevented malformed or incomplete fragments from being delivered as complete messages.

* **Tests**
  * Added comprehensive coverage for fragmentation, reassembly, sequencing, limits, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->