### PR TITLE
fix: preserve sequencing across fragmentation

### DIFF
--- a/Assets/PurrNet/Runtime/CoreModules/Broadcast/BroadcastModule.cs
+++ b/Assets/PurrNet/Runtime/CoreModules/Broadcast/BroadcastModule.cs
@@ -112,6 +112,16 @@ namespace PurrNet.Modules
                 return true;
 
             var mtu = _transport.GetMTU(conn, method, _asServer);
+            bool sequenceThroughFragmentation = method == Channel.UnreliableSequenced &&
+                                                _networkManager.mtuExceededBehaviour ==
+                                                MTUExceededBehaviour.Fragment;
+
+            if (sequenceThroughFragmentation)
+            {
+                SendFragmented<T>(conn, byteData, method, mtu, true);
+                return false;
+            }
+
             if (byteData.length <= mtu)
                 return true;
 
@@ -129,28 +139,38 @@ namespace PurrNet.Modules
                         $"Dropping {method} packet.");
                     return false;
                 case MTUExceededBehaviour.Fragment:
-                    int maxMessageSize = FragmentationLayer.GetMaxMessageSize(mtu, FRAGMENT_FRAME_PREFIX);
-                    if (byteData.length > maxMessageSize)
-                    {
-                        PurrLogger.LogError(
-                            $"Cannot fragment `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}). " +
-                            $"Maximum unreliable message size is {maxMessageSize} bytes. Dropping packet.");
-                        return false;
-                    }
-
-                    try
-                    {
-                        var state = new FragmentSendState(this, conn, method);
-                        _fragmentation.Send(byteData, mtu, FRAGMENT_FRAME_PREFIX, state, _sendFragment);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        PurrLogger.LogError(
-                            $"Cannot fragment `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}): {e.Message}");
-                    }
+                    SendFragmented<T>(conn, byteData, method, mtu, false);
                     return false;
                 default:
                     return true;
+            }
+        }
+
+        void SendFragmented<T>(Connection conn, ByteData byteData, Channel method, int mtu, bool sequenced)
+        {
+            int maxMessageSize = sequenced
+                ? FragmentationLayer.GetMaxSequencedMessageSize(mtu, FRAGMENT_FRAME_PREFIX)
+                : FragmentationLayer.GetMaxMessageSize(mtu, FRAGMENT_FRAME_PREFIX);
+            if (byteData.length > maxMessageSize)
+            {
+                PurrLogger.LogError(
+                    $"Cannot fragment `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}). " +
+                    $"Maximum unreliable message size is {maxMessageSize} bytes. Dropping packet.");
+                return;
+            }
+
+            try
+            {
+                var state = new FragmentSendState(this, conn, method);
+                if (sequenced)
+                    _fragmentation.SendSequenced(byteData, mtu, FRAGMENT_FRAME_PREFIX, state, _sendFragment);
+                else
+                    _fragmentation.Send(byteData, mtu, FRAGMENT_FRAME_PREFIX, state, _sendFragment);
+            }
+            catch (ArgumentException e)
+            {
+                PurrLogger.LogError(
+                    $"Cannot fragment `{typeof(T)}` ({byteData.length} bytes, MTU {mtu}): {e.Message}");
             }
         }
 

--- a/Assets/PurrNet/Runtime/Transports/FragmentationLayer.cs
+++ b/Assets/PurrNet/Runtime/Transports/FragmentationLayer.cs
@@ -11,6 +11,7 @@ namespace PurrNet.Transports
     ///
     /// Header format:
     ///   Unfragmented: [1 byte: 0x00] [payload]
+    ///   Sequenced:    [1 byte: 0x02] [4 bytes: messageId] [payload]
     ///   Fragmented:   [1 byte: 0x01] [4 bytes: messageId] [4 bytes: totalLength]
     ///                 [2 bytes: fragmentStride] [1 byte: fragmentIndex]
     ///                 [1 byte: totalFragments] [payload]
@@ -21,6 +22,9 @@ namespace PurrNet.Transports
 
         /// <summary>Header overhead for unfragmented messages.</summary>
         public const int UNFRAGMENTED_OVERHEAD = 1;
+
+        /// <summary>Header overhead for sequenced, unfragmented messages.</summary>
+        public const int SEQUENCED_OVERHEAD = 5;
 
         /// <summary>Header overhead per fragmented message packet.</summary>
         public const int FRAGMENT_OVERHEAD = 13;
@@ -36,6 +40,7 @@ namespace PurrNet.Transports
 
         const byte FLAG_UNFRAGMENTED = 0;
         const byte FLAG_FRAGMENTED = 1;
+        const byte FLAG_SEQUENCED = 2;
 
         static readonly FragmentCallback<Action<ByteData>> _invokeAction = InvokeAction;
 
@@ -170,6 +175,13 @@ namespace PurrNet.Transports
             return (int)Math.Min(result, MAX_MESSAGE_SIZE);
         }
 
+        /// <summary>Returns the largest sequenced message accepted for the supplied packet size.</summary>
+        public static int GetMaxSequencedMessageSize(int mtu, int reservedPrefix = 0)
+        {
+            int singlePacketPayload = Math.Max(0, mtu - reservedPrefix - SEQUENCED_OVERHEAD);
+            return Math.Max(singlePacketPayload, GetMaxMessageSize(mtu, reservedPrefix));
+        }
+
         /// <summary>
         /// Sends a message with no prefix reserved for the caller.
         /// </summary>
@@ -182,6 +194,18 @@ namespace PurrNet.Transports
         }
 
         /// <summary>
+        /// Sends a message on a sequenced stream. Even a single-packet message carries a message id
+        /// so it can invalidate older incomplete fragmented messages on the same stream.
+        /// </summary>
+        public void SendSequenced(ByteData data, int mtu, Action<ByteData> sendFragment)
+        {
+            if (sendFragment == null)
+                throw new ArgumentNullException(nameof(sendFragment));
+
+            Send(data, mtu, 0, sendFragment, _invokeAction, true);
+        }
+
+        /// <summary>
         /// Splits a message into packets no larger than <paramref name="mtu"/>. The caller may
         /// reserve bytes at the front of every packet for its own framing and must overwrite all
         /// reserved bytes in the callback. Buffers passed to the callback are reused and are only
@@ -190,18 +214,37 @@ namespace PurrNet.Transports
         public void Send<TState>(ByteData data, int mtu, int reservedPrefix, TState state,
             FragmentCallback<TState> sendFragment)
         {
+            Send(data, mtu, reservedPrefix, state, sendFragment, false);
+        }
+
+        /// <summary>
+        /// Sends on a sequenced stream while reserving a caller-owned prefix. Single-packet and
+        /// fragmented messages share the same monotonically increasing message-id space.
+        /// </summary>
+        public void SendSequenced<TState>(ByteData data, int mtu, int reservedPrefix, TState state,
+            FragmentCallback<TState> sendFragment)
+        {
+            Send(data, mtu, reservedPrefix, state, sendFragment, true);
+        }
+
+        void Send<TState>(ByteData data, int mtu, int reservedPrefix, TState state,
+            FragmentCallback<TState> sendFragment, bool sequenced)
+        {
             if (sendFragment == null)
                 throw new ArgumentNullException(nameof(sendFragment));
             if (reservedPrefix < 0)
                 throw new ArgumentOutOfRangeException(nameof(reservedPrefix));
 
-            if (data.length + reservedPrefix + UNFRAGMENTED_OVERHEAD <= mtu)
+            int singlePacketOverhead = sequenced ? SEQUENCED_OVERHEAD : UNFRAGMENTED_OVERHEAD;
+            if (data.length + reservedPrefix + singlePacketOverhead <= mtu)
             {
-                int packetLength = reservedPrefix + UNFRAGMENTED_OVERHEAD + data.length;
+                int packetLength = reservedPrefix + singlePacketOverhead + data.length;
                 EnsureBuffer(ref _sendBuffer, packetLength);
-                _sendBuffer.array[reservedPrefix] = FLAG_UNFRAGMENTED;
+                _sendBuffer.array[reservedPrefix] = sequenced ? FLAG_SEQUENCED : FLAG_UNFRAGMENTED;
+                if (sequenced)
+                    WriteUInt32(_sendBuffer.array, reservedPrefix + 1, NextMessageId());
                 Buffer.BlockCopy(data.data, data.offset, _sendBuffer.array,
-                    reservedPrefix + UNFRAGMENTED_OVERHEAD, data.length);
+                    reservedPrefix + singlePacketOverhead, data.length);
                 sendFragment(new ByteData(_sendBuffer.array, 0, packetLength), state);
                 return;
             }
@@ -220,7 +263,7 @@ namespace PurrNet.Transports
                     $"Data ({data.length} bytes) exceeds max fragmentable size for MTU {mtu}. " +
                     $"Max: {GetMaxMessageSize(mtu, reservedPrefix)} bytes.", nameof(data));
 
-            uint messageId = _nextMessageId++;
+            uint messageId = NextMessageId();
 
             for (int i = 0; i < totalFragments; i++)
             {
@@ -252,7 +295,7 @@ namespace PurrNet.Transports
 
         /// <summary>
         /// Processes a packet for a sender and logical stream. Sequenced streams discard older
-        /// incomplete messages as soon as a newer fragmented message is observed. Reassembled
+        /// incomplete messages as soon as any newer message is observed. Reassembled
         /// data remains valid until the next completed reassembly, <see cref="Reset"/>, or disposal.
         /// </summary>
         public bool Receive(int senderId, byte streamId, bool sequenced, ByteData data, out ByteData assembled)
@@ -269,6 +312,20 @@ namespace PurrNet.Transports
             {
                 assembled = new ByteData(data.data, header + UNFRAGMENTED_OVERHEAD,
                     data.length - UNFRAGMENTED_OVERHEAD);
+                return true;
+            }
+
+            if (flag == FLAG_SEQUENCED)
+            {
+                if (!sequenced || data.length < SEQUENCED_OVERHEAD)
+                    return false;
+
+                uint completedMessageId = ReadUInt32(data.data, header + 1);
+                if (!AcceptCompletedSequenced(senderId, streamId, completedMessageId))
+                    return false;
+
+                assembled = new ByteData(data.data, header + SEQUENCED_OVERHEAD,
+                    data.length - SEQUENCED_OVERHEAD);
                 return true;
             }
 
@@ -405,6 +462,14 @@ namespace PurrNet.Transports
 
         public void Dispose() => Reset();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        uint NextMessageId()
+        {
+            uint messageId = _nextMessageId;
+            _nextMessageId = unchecked(messageId + 1);
+            return messageId;
+        }
+
         bool AcceptSequenced(ReassemblyKey key, bool hasEntry)
         {
             var stream = new StreamKey(key.senderId, key.streamId);
@@ -423,6 +488,24 @@ namespace PurrNet.Transports
 
             DiscardStream(stream);
             _latestSequencedMessages[stream] = key.messageId;
+            return true;
+        }
+
+        bool AcceptCompletedSequenced(int senderId, byte streamId, uint messageId)
+        {
+            var stream = new StreamKey(senderId, streamId);
+            if (!_latestSequencedMessages.TryGetValue(stream, out uint latest))
+            {
+                _latestSequencedMessages.Add(stream, messageId);
+                return true;
+            }
+
+            int relative = unchecked((int)(messageId - latest));
+            if (relative <= 0)
+                return false;
+
+            DiscardStream(stream);
+            _latestSequencedMessages[stream] = messageId;
             return true;
         }
 

--- a/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BitPackerEdgeCaseTests.cs
@@ -572,6 +572,39 @@ public class BitPackerEdgeCaseTests
     }
 
     [Test]
+    public void FragmentationLayer_SequencedWrap_NewSinglePacketInvalidatesOldFragments()
+    {
+        using var sender = new FragmentationLayer();
+        using var receiver = new FragmentationLayer();
+        var nextId = typeof(FragmentationLayer).GetField("_nextMessageId",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(nextId);
+        nextId.SetValue(sender, uint.MaxValue);
+
+        var oldPayload = new byte[35];
+        var newPayload = new byte[] { 10, 20, 30, 40 };
+        var oldFragments = new List<byte[]>();
+        var newPackets = new List<byte[]>();
+        sender.SendSequenced(new ByteData(oldPayload, 0, oldPayload.Length), 24,
+            packet => Capture(packet, oldFragments));
+        sender.SendSequenced(new ByteData(newPayload, 0, newPayload.Length), 24,
+            packet => Capture(packet, newPackets));
+
+        Assert.Greater(oldFragments.Count, 1);
+        Assert.AreEqual(1, newPackets.Count);
+        Assert.IsFalse(receiver.Receive(1, 1, true,
+            new ByteData(oldFragments[0], 0, oldFragments[0].Length), out _));
+        Assert.IsTrue(receiver.Receive(1, 1, true,
+            new ByteData(newPackets[0], 0, newPackets[0].Length), out var assembled));
+
+        for (int i = 1; i < oldFragments.Count; i++)
+            Assert.IsFalse(receiver.Receive(1, 1, true,
+                new ByteData(oldFragments[i], 0, oldFragments[i].Length), out _));
+
+        AssertByteDataEquals(new ByteData(newPayload, 0, newPayload.Length), assembled);
+    }
+
+    [Test]
     public void ValidatedSyncVar_ServerValidation_RemovesLastMatchingSubscriber()
     {
         var syncVar = new ValidatedSyncVar<int>(0);

--- a/Assets/Tests/BitPacker.Tests/BroadcastFragmentationTests.cs
+++ b/Assets/Tests/BitPacker.Tests/BroadcastFragmentationTests.cs
@@ -206,6 +206,36 @@ public class BroadcastFragmentationTests
     }
 
     [Test]
+    public void UnreliableSequenced_NewerUnderMTUMessageInvalidatesOlderIncompleteMessage()
+    {
+        var transport = new TestTransport { mtu = 64 };
+        var sender = new BroadcastModule(new TestManager(transport, MTUExceededBehaviour.Fragment), true);
+        var receiver = new BroadcastModule(
+            new TestManager(new TestTransport(), MTUExceededBehaviour.Fragment), false);
+        var connection = new Connection(6);
+        string oldValue = CreatePayload(250, 3);
+        const string newValue = "new-small-value";
+        var received = new List<string>();
+        receiver.Subscribe<string>((_, value, _) => received.Add(value));
+
+        sender.Send(connection, oldValue, Channel.UnreliableSequenced);
+        int oldFragmentCount = transport.sent.Count;
+        sender.Send(connection, newValue, Channel.UnreliableSequenced);
+
+        Assert.Greater(oldFragmentCount, 1);
+        Assert.AreEqual(oldFragmentCount + 1, transport.sent.Count);
+
+        Deliver(receiver, connection, transport.sent[0]);
+        Deliver(receiver, connection, transport.sent[oldFragmentCount]);
+
+        for (int i = 1; i < oldFragmentCount; i++)
+            Deliver(receiver, connection, transport.sent[i]);
+
+        Assert.AreEqual(1, received.Count);
+        Assert.AreEqual(newValue, received[0]);
+    }
+
+    [Test]
     public void UnderMTUUnreliableMessage_UsesOriginalSinglePacketPath()
     {
         var transport = new TestTransport { mtu = 256 };


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786371251&installation_id=129033668&pr_number=272&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F272&signature=ea63016b0cdb35bb4c6f5da5a5f3467e94ede43dec87ffc059d46acb534aee34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unreliable sequenced messaging when packets exceed the MTU.
  * Newer messages now correctly supersede older incomplete or fragmented messages.
  * Enhanced handling of sequenced packet delivery and message reassembly.

* **Tests**
  * Added coverage for message ID wraparound and sequenced message replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->