### PR TITLE
Fixed last send time didn't reset

### DIFF
--- a/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
+++ b/Assets/PurrNet/Runtime/Managers/NetworkManager.cs
@@ -1907,6 +1907,8 @@ namespace PurrNet
         {
             if (!_transport)
                 PurrLogger.Throw<InvalidOperationException>("Transport is not set (null).");
+            
+            _lastSendTime = 0d;
             _transport.StartServer(this);
         }
 
@@ -2208,6 +2210,8 @@ namespace PurrNet
                 yield return null;
             while (_isCleaningClient)
                 yield return null;
+            
+            _lastSendTime = 0d;
             _transport.StartClient(this);
         }
 


### PR DESCRIPTION
Hosting works the first time, but after disconnecting, hosting again can instantly fail because of a timeout if NetworkManager is DDOL.

Maybe it’s something wrong with my setup, since I’m using a lobby system I originally wrote for FishNet with the same DDOL setup. But after switching to PurrNet, I started getting this issue where the host needs to press the Host button a few times when hosting again in the same play mode session.

Today I finally looked into why it happens and found the reason.

NetworkManager keeps the old _lastSendTime. On the next session, it treats the time since the previous session as the first network update delta, so LiteNetLib immediately thinks the connection timed out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786705760&installation_id=129033668&pr_number=273&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F273&signature=1ef5ecf0b543748139ad620e105f44164ee97ee6c8f7b417dd205eecfa4ab615"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->