### PR TITLE
feat: add ownerOnly option to SyncVar

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncVar.cs
@@ -21,9 +21,14 @@ namespace PurrNet
         [SerializeField, Space(-5), Header("Sync Settings"), PurrLock]
         private bool _ownerAuth;
 
+        [SerializeField, PurrLock]
+        private bool _ownerOnly;
+
         [SerializeField, Min(0)] private float _sendIntervalInSeconds;
 
         public bool ownerAuth => _ownerAuth;
+
+        public bool ownerOnly => _ownerOnly;
 
         public float sendIntervalInSeconds
         {
@@ -92,7 +97,7 @@ namespace PurrNet
         {
             InvalidateIsController();
 
-            if (_ownerAuth && isServer)
+            if (isServer && (_ownerAuth || _ownerOnly))
                 SendLatestState(ownerId, _id, _value);
         }
 
@@ -110,6 +115,15 @@ namespace PurrNet
 
                 if (isOwner)
                     SetDirty();
+            }
+
+            if (asServer && _ownerOnly)
+            {
+                if (oldOwner.HasValue && oldOwner != newOwner)
+                    SendLatestState(oldOwner.Value, _id, _initialValue);
+
+                if (!_ownerAuth && newOwner.HasValue)
+                    SendLatestState(newOwner.Value, _id, _value);
             }
         }
 
@@ -160,6 +174,9 @@ namespace PurrNet
 
         public override void OnObserverAdded(PlayerID player, bool isSpawner)
         {
+            if (_ownerOnly && owner != player)
+                return;
+
             if (isSpawner && ownerAuth && owner == player)
                 return;
 
@@ -210,16 +227,22 @@ namespace PurrNet
 
         private void ForceSendUnreliable()
         {
-            if (isServer)
+            if (!isServer)
+                SendToServer(++_id, _value);
+            else if (!_ownerOnly)
                 SendToAll(++_id, _value);
-            else SendToServer(++_id, _value);
+            else if (owner.HasValue)
+                SendToOwner(owner.Value, ++_id, _value);
         }
 
         private void ForceSendReliable()
         {
-            if (isServer)
+            if (!isServer)
+                SendToServerReliably(++_id, _value);
+            else if (!_ownerOnly)
                 SendToAllReliably(++_id, _value);
-            else SendToServerReliably(++_id, _value);
+            else if (owner.HasValue)
+                SendToOwnerReliably(owner.Value, ++_id, _value);
         }
 
         public void FlushImmediately()
@@ -267,12 +290,13 @@ namespace PurrNet
         [SerializeField, HideInInspector]
         private T _initialValue;
 
-        public SyncVar(T initialValue = default, float sendIntervalInSeconds = 0f, bool ownerAuth = false)
+        public SyncVar(T initialValue = default, float sendIntervalInSeconds = 0f, bool ownerAuth = false, bool ownerOnly = false)
         {
             _initialValue = initialValue;
             _value = initialValue;
             _sendIntervalInSeconds = sendIntervalInSeconds;
             _ownerAuth = ownerAuth;
+            _ownerOnly = ownerOnly;
         }
 
         [TargetRpc, UsedImplicitly]
@@ -298,6 +322,24 @@ namespace PurrNet
             TriggerEvents(oldValue);
         }
 
+        [TargetRpc(Channel.Unreliable)]
+        private void SendToOwner(PlayerID player, PackedULong packetId, T newValue)
+        {
+            if (isServer)
+                return;
+
+            OnReceivedValue(packetId, newValue);
+        }
+
+        [TargetRpc(Channel.ReliableOrdered)]
+        private void SendToOwnerReliably(PlayerID player, PackedULong packetId, T newValue)
+        {
+            if (isServer)
+                return;
+
+            OnReceivedValue(packetId, newValue);
+        }
+
         [ServerRpc(Channel.Unreliable, requireOwnership: true)]
         private void SendToServer(PackedULong packetId, T newValue)
         {
@@ -305,7 +347,8 @@ namespace PurrNet
                 return;
 
             OnReceivedValue(packetId, newValue);
-            SendToOthers(packetId, newValue);
+            if (!_ownerOnly)
+                SendToOthers(packetId, newValue);
         }
 
         [ServerRpc(Channel.ReliableOrdered, requireOwnership: true)]
@@ -315,7 +358,8 @@ namespace PurrNet
                 return;
 
             OnReceivedValue(packetId, newValue);
-            SendToOthersReliably(packetId, newValue);
+            if (!_ownerOnly)
+                SendToOthersReliably(packetId, newValue);
         }
 
         [ObserversRpc(Channel.Unreliable, excludeOwner: true)]


### PR DESCRIPTION
Syncs the value only between the server and the current owner. I followed in the footsteps of #204 and made it a flag on the                                                                                                                                                                                       existing SyncVar like was suggested there

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787417608&installation_model_id=20441&pr_number=286&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F286&signature=7f95bce52a33da1919b90685d2a784c3f4fc0ce4fb998388481f4a5f6d248cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->