### PR TITLE
fix: reset PlayerIdentity and SyncEvent using OnPoolReset

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkIdentity/PlayerIdentity.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkIdentity/PlayerIdentity.cs
@@ -46,6 +46,14 @@ namespace PurrNet
             _allPlayers.Remove(this as T);
         }
 
+        protected override void OnPoolReset()
+        {
+            base.OnPoolReset();
+
+            _allPlayers.Remove(this as T);
+            _oldRegisteredOwner = null;
+        }
+
         public static bool TryGetLocal(out T player)
         {
             if (!NetworkManager.main)

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncEvent.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncEvent.cs
@@ -86,6 +86,12 @@ namespace PurrNet
         protected abstract void InvokeUnityEvent(T data);
         protected virtual void ClearUnityEvent() { }
 
+        public override void OnPoolReset()
+        {
+            ClearUnityEvent();
+            _lastData.Dispose();
+        }
+
         public void InvokePacket(SyncEventData data)
         {
             if (!ValidateInvoke())
@@ -378,6 +384,7 @@ namespace PurrNet
         }
 
         protected override void InvokeUnityEvent((T1, T2, T3, T4, T5) data) => unityEvent?.Invoke(data.Item1, data.Item2, data.Item3, data.Item4, data.Item5);
+        protected override void ClearUnityEvent() => unityEvent = null;
 
         public static SyncEvent<T1, T2, T3, T4, T5> operator +(SyncEvent<T1, T2, T3, T4, T5> e, Action<T1, T2, T3, T4, T5> listener)
         {


### PR DESCRIPTION
Add OnPoolReset override to SyncEvent to call ClearUnityEvent and dispose _lastData so cached data is freed and listeners are cleared when objects are returned to the pool. Implement ClearUnityEvent for the 5-arg generic specialization (sets unityEvent = null) to avoid subscriber persistence and potential memory leaks. File changed: Assets/PurrNet/Runtime/Components/NetworkModule/SyncEvent.cs


Override OnPoolReset in PlayerIdentity to call base, remove the instance from the static _allPlayers collection, and null out _oldRegisteredOwner. This prevents stale references and duplicate entries when player identities are returned to the object pool, avoiding memory leaks and incorrect owner data after reuse.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787754310&installation_model_id=20441&pr_number=290&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F290&signature=69c6d2e1eb09898c1fb2d3d66e43df7f1686c640adddfff516784b6c0e547a06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->