### PR TITLE
Add pooling and serialization support to SyncInput

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncInput.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncInput.cs
@@ -13,16 +13,19 @@ namespace PurrNet
     /// </summary>
     /// <typeparam name="T">Type to sync to the server</typeparam>
     [System.Serializable]
-    public class SyncInput<T> : NetworkModule, ITick where T : unmanaged, System.IEquatable<T>
+    public class SyncInput<T> : NetworkModule, ITick, ISerializationCallbackReceiver where T : unmanaged, System.IEquatable<T>
     {
         public SyncInput(T defaultValue = default, float hostPing = 0f)
         {
             _value = defaultValue;
+            _initialValue = defaultValue;
             _simulatedHostPing = hostPing;
         }
-        
+
         [SerializeField, PurrLock] private T _value;
-        
+
+        [SerializeField, HideInInspector] private T _initialValue;
+
         [Tooltip("Simulated ping in ms. This is only for the host to simulate a ping delay.")]
         [SerializeField, PurrLock] private float _simulatedHostPing;
         
@@ -31,7 +34,6 @@ namespace PurrNet
         private int _lastAckId;
         private bool _isDirty;
         private Dictionary<int, T> _history = new();
-        private float _hostSimDelayTimer;
         private T _queuedHostValue, _lastQueuedHostValue;
 
         private readonly Queue<PendingInput> _pendingHostInputs = new();
@@ -92,6 +94,31 @@ namespace PurrNet
                     value = 0;
                 _simulatedHostPing = value;
             }
+        }
+
+        public override void OnPoolReset()
+        {
+            onChanged = null;
+            onSentData = null;
+
+            _value = _initialValue;
+            _lastValue = default;
+            _currentId = 0;
+            _lastAckId = 0;
+            _isDirty = false;
+            _history.Clear();
+            _queuedHostValue = _initialValue;
+            _lastQueuedHostValue = _initialValue;
+            _pendingHostInputs.Clear();
+        }
+
+        public void OnBeforeSerialize()
+        {
+        }
+
+        public void OnAfterDeserialize()
+        {
+            _initialValue = _value;
         }
 
         public void SetDirty()


### PR DESCRIPTION
Implement object pooling reset functionality and serialization callbacks for SyncInput. Store the initial value on deserialization to enable proper state restoration via OnPoolReset(). This ensures cached instances return to their original state when reused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787766911&installation_model_id=20441&pr_number=291&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F291&signature=f1fb8e54e934f4693020d71ed6e60ed0e39d0df1d7d0ea7a86667e4066b07041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->