### PR TITLE
fix(codegen): make serializer registration CoreCLR-safe

### DIFF
--- a/Assets/PurrNet/Codegen/DuplicateHelpers.cs
+++ b/Assets/PurrNet/Codegen/DuplicateHelpers.cs
@@ -27,6 +27,12 @@ namespace PurrNet.Codegen
 
         public static bool HasDuplicateInterface(TypeReference def)
         {
+            // Arrays/pointers/byrefs resolve to their ELEMENT type in Cecil (Filter[].Resolve() == Filter),
+            // a false positive. A composite type never implements IDuplicate<itself>, and injecting
+            // Override<Filter[]>() violates 'where D : IDuplicate<D>' (CoreCLR VerificationException).
+            if (def is ArrayType || def is PointerType || def is ByReferenceType)
+                return false;
+
             var resolved = def.Resolve();
             return resolved != null && HasDuplicateInterface(resolved);
         }

--- a/Assets/PurrNet/Codegen/DuplicateHelpers.cs
+++ b/Assets/PurrNet/Codegen/DuplicateHelpers.cs
@@ -27,9 +27,6 @@ namespace PurrNet.Codegen
 
         public static bool HasDuplicateInterface(TypeReference def)
         {
-            // Arrays/pointers/byrefs resolve to their ELEMENT type in Cecil (Filter[].Resolve() == Filter),
-            // a false positive. A composite type never implements IDuplicate<itself>, and injecting
-            // Override<Filter[]>() violates 'where D : IDuplicate<D>' (CoreCLR VerificationException).
             if (def is ArrayType || def is PointerType || def is ByReferenceType)
                 return false;
 

--- a/Assets/PurrNet/Codegen/EquatableHelpers.cs
+++ b/Assets/PurrNet/Codegen/EquatableHelpers.cs
@@ -27,9 +27,6 @@ namespace PurrNet.Codegen
 
         public static bool HasEquatableInterface(TypeReference def)
         {
-            // Arrays/pointers/byrefs resolve to their ELEMENT type in Cecil (Filter[].Resolve() == Filter),
-            // a false positive. A composite type never implements IPurrEquatable<itself>, and injecting
-            // Override<Filter[]>() violates 'where D : IPurrEquatable<D>' (CoreCLR VerificationException).
             if (def is ArrayType || def is PointerType || def is ByReferenceType)
                 return false;
 

--- a/Assets/PurrNet/Codegen/EquatableHelpers.cs
+++ b/Assets/PurrNet/Codegen/EquatableHelpers.cs
@@ -27,6 +27,12 @@ namespace PurrNet.Codegen
 
         public static bool HasEquatableInterface(TypeReference def)
         {
+            // Arrays/pointers/byrefs resolve to their ELEMENT type in Cecil (Filter[].Resolve() == Filter),
+            // a false positive. A composite type never implements IPurrEquatable<itself>, and injecting
+            // Override<Filter[]>() violates 'where D : IPurrEquatable<D>' (CoreCLR VerificationException).
+            if (def is ArrayType || def is PointerType || def is ByReferenceType)
+                return false;
+
             var resolved = def.Resolve();
             return resolved != null && HasEquatableInterface(resolved);
         }

--- a/Assets/PurrNet/Codegen/GenerateSerializersProcessor.cs
+++ b/Assets/PurrNet/Codegen/GenerateSerializersProcessor.cs
@@ -113,11 +113,6 @@ namespace PurrNet.Codegen
             if (!PostProcessor.IsTypeInOwnModule(type, assembly.MainModule))
                 return;
 
-            // The generated serializer class is a separate top-level type, so every generic call it
-            // emits over 'type' (PackCollections.Register*, RegisterIdentity, RegisterNetworkModule,
-            // PurrCopy/PurrEquality.Override) needs 'type' to be accessible from it. CoreCLR verifies
-            // this; Mono/IL2CPP did not. The IsTypeInOwnModule guard above means we only ever promote
-            // types in the module we are already rewriting.
             RegisterSerializersProcessor.EnsureCoreClrAccessible(type, assembly.MainModule);
 
             var resolvedType = type.Resolve();

--- a/Assets/PurrNet/Codegen/GenerateSerializersProcessor.cs
+++ b/Assets/PurrNet/Codegen/GenerateSerializersProcessor.cs
@@ -113,6 +113,13 @@ namespace PurrNet.Codegen
             if (!PostProcessor.IsTypeInOwnModule(type, assembly.MainModule))
                 return;
 
+            // The generated serializer class is a separate top-level type, so every generic call it
+            // emits over 'type' (PackCollections.Register*, RegisterIdentity, RegisterNetworkModule,
+            // PurrCopy/PurrEquality.Override) needs 'type' to be accessible from it. CoreCLR verifies
+            // this; Mono/IL2CPP did not. The IsTypeInOwnModule guard above means we only ever promote
+            // types in the module we are already rewriting.
+            RegisterSerializersProcessor.EnsureCoreClrAccessible(type, assembly.MainModule);
+
             var resolvedType = type.Resolve();
             if (resolvedType == null)
                 return;

--- a/Assets/PurrNet/Codegen/RegisterSerializersProcessor.cs
+++ b/Assets/PurrNet/Codegen/RegisterSerializersProcessor.cs
@@ -100,11 +100,6 @@ namespace PurrNet.Codegen
             public MethodDefinition method;
         }
 
-        // CoreCLR enforces member-access verification that Mono/IL2CPP did not. Creating a
-        // WriteFunc<T>/ReadFunc<T> delegate inside the generated serializer class requires that T
-        // (and every enclosing type in its declaring chain) be accessible from that class. Private/
-        // internal nested serialized types therefore throw MethodAccessException at 'newobj'. The
-        // serializer is always generated into the same module as T, so promoting it is self-contained.
         public static void EnsureCoreClrAccessible(TypeReference typeRef, ModuleDefinition module)
         {
             switch (typeRef)
@@ -121,8 +116,7 @@ namespace PurrNet.Codegen
             }
 
             var resolved = typeRef.Resolve();
-            // A public nested type inside a private parent is still inaccessible, so walk the chain.
-            // Top-level types are left untouched (internal top-level is already same-assembly accessible).
+
             while (resolved != null && resolved.IsNested && resolved.Module == module)
             {
                 if (!resolved.IsNestedPublic)

--- a/Assets/PurrNet/Codegen/RegisterSerializersProcessor.cs
+++ b/Assets/PurrNet/Codegen/RegisterSerializersProcessor.cs
@@ -100,6 +100,37 @@ namespace PurrNet.Codegen
             public MethodDefinition method;
         }
 
+        // CoreCLR enforces member-access verification that Mono/IL2CPP did not. Creating a
+        // WriteFunc<T>/ReadFunc<T> delegate inside the generated serializer class requires that T
+        // (and every enclosing type in its declaring chain) be accessible from that class. Private/
+        // internal nested serialized types therefore throw MethodAccessException at 'newobj'. The
+        // serializer is always generated into the same module as T, so promoting it is self-contained.
+        public static void EnsureCoreClrAccessible(TypeReference typeRef, ModuleDefinition module)
+        {
+            switch (typeRef)
+            {
+                case null: return;
+                case GenericInstanceType git:
+                    EnsureCoreClrAccessible(git.ElementType, module);
+                    foreach (var arg in git.GenericArguments)
+                        EnsureCoreClrAccessible(arg, module);
+                    return;
+                case ByReferenceType byRef: EnsureCoreClrAccessible(byRef.ElementType, module); return;
+                case ArrayType arr:         EnsureCoreClrAccessible(arr.ElementType, module);   return;
+                case PointerType ptr:       EnsureCoreClrAccessible(ptr.ElementType, module);   return;
+            }
+
+            var resolved = typeRef.Resolve();
+            // A public nested type inside a private parent is still inaccessible, so walk the chain.
+            // Top-level types are left untouched (internal top-level is already same-assembly accessible).
+            while (resolved != null && resolved.IsNested && resolved.Module == module)
+            {
+                if (!resolved.IsNestedPublic)
+                    resolved.IsNestedPublic = true;
+                resolved = resolved.DeclaringType?.Resolve();
+            }
+        }
+
         public static void HandleType(TypeReference actualType, ModuleDefinition module, TypeDefinition type,
             HashSet<TypeReference> toIgnoreForDelta, HashSet<TypeReference> toIgnoreForSerialization)
         {
@@ -228,6 +259,7 @@ namespace PurrNet.Codegen
             for (int i = 0; i < writeTypes.Count; i++)
             {
                 var writeType = writeTypes[i];
+                EnsureCoreClrAccessible(writeType.type, module);
                 var writeMethod = writeType.method.Import(module);
                 var resolved = writeMethod.Resolve();
                 resolved.IsPublic = true;
@@ -320,6 +352,8 @@ namespace PurrNet.Codegen
                 {
                     typeArgument = byRefType.ElementType; // Use the base type (e.g., int from ref int)
                 }
+
+                EnsureCoreClrAccessible(typeArgument, module);
 
                 var packerType = module.GetTypeDefinition(typeof(Packer<>)).Import(module);
                 var deltaPackerType = module.GetTypeDefinition(typeof(DeltaPacker<>)).Import(module);


### PR DESCRIPTION
Unity's CoreCLR scripting backend enforces member-access and generic-constraint verification that Mono/IL2CPP skipped. Several codegen paths emitted IL that relied on that verification being absent, so [RegisterPackers] type registration threw during NetworkManager.Awake and left the Hasher/Packer empty - no networked type registered at all, making the runtime non-functional.

1) MethodAccessException on WriteFunc<T>/ReadFunc<T> delegates

RegisterSerializersProcessor.HandleType promotes the write/read method to public but never the type argument T. When T is a private/internal nested type (e.g. BroadcastModule.FragmentSendState), the separate generated serializer class cannot access it and the delegate 'newobj' throws.

Added EnsureCoreClrAccessible, which walks the whole declaring-type chain (a public nested type inside a private parent is still inaccessible) and recurses through generic/array/pointer/byref composites. Top-level types are left alone: internal top-level is already same-assembly accessible.

2) MethodAccessException on the generated Register() generic calls

The generated serializer class also emits generic calls over the type itself - PackCollections.RegisterArray/RegisterList/RegisterDictionary/..., RegisterIdentity, RegisterNetworkModule and PurrCopy/PurrEquality.Override - which likewise require the type argument to be accessible from that class. Hit in practice with a jagged array of PredictionManager.CachedFilteredInputBlock, a private nested struct.

Promoted once in GenerateSerializersProcessor.HandleType, immediately after the existing IsTypeInOwnModule guard. HandleType is the only entry point from PostProcessor and all three generator paths (HandleGenerics, HandleNetworkIdentity, HandleNetworkModule) route through it, so a single call covers every emission site while inheriting the same-module guard that makes promotion safe.

3) VerificationException on IDuplicate/IPurrEquatable array false-positive

In Cecil, ArrayType.Resolve() returns the ELEMENT type's definition, so HasDuplicateInterface(Filter[]) resolves to Filter, sees IDuplicate<Filter> and returns true. HandleType then injects PurrCopy.Override<Filter[]>(), violating 'where D : IDuplicate<D>'. Same for IPurrEquatable/PurrEquality.Override. Guard both helpers against composite types before resolving; arrays are duplicated/compared element-wise via the element type anyway.

All fixes are backend-agnostic and correct on Mono/IL2CPP as well. Verified on Unity 6000.7.0a2 CoreCLR, Windows Standalone: registration now completes and the network starts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787918388&installation_model_id=20441&pr_number=294&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F294&signature=753bdbd085a8c007f91dfa81c0d4040e149cfaafa85b8cd64a77a37c457636be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->