### PR TITLE
SyncList and SyncDictionary initial state sync

### DIFF
--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
@@ -155,18 +155,10 @@ namespace PurrNet
         {
             _initialSerializedDict.CopyTo(_dict);
         }
-
-        public override void OnSpawn()
-        {
-            base.OnSpawn();
-        }
-
+        
         public override void OnSpawnSent()
         {
             if (isServer || !IsController(_ownerAuth))
-                return;
-
-            if (!_isDirty)
                 return;
 
             SendInitialStateToServer(_dict);

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
@@ -159,16 +159,27 @@ namespace PurrNet
         public override void OnSpawn()
         {
             base.OnSpawn();
-
-            if (!IsController(_ownerAuth)) return;
-
-            if (isServer)
-                SendInitialStateToAll(_dict);
-            else SendInitialStateToServer(_dict);
         }
 
-        public override void OnObserverAdded(PlayerID player)
+        public override void OnSpawnSent()
         {
+            if (isServer || !IsController(_ownerAuth))
+                return;
+
+            if (!_isDirty)
+                return;
+
+            SendInitialStateToServer(_dict);
+            _pendingChanges.Clear();
+            _isDirty = false;
+            _wasLastDirty = false;
+        }
+
+        public override void OnObserverAdded(PlayerID player, bool isSpawner)
+        {
+            if (isSpawner && ownerAuth && owner == player)
+                return;
+
             HandleInitialStateTarget(player, _dict);
         }
 

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncDictionary.cs
@@ -3,6 +3,7 @@ using PurrNet.Logging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using PurrNet.Packing;
 using PurrNet.Transports;
 
 namespace PurrNet
@@ -159,6 +160,9 @@ namespace PurrNet
         public override void OnSpawnSent()
         {
             if (isServer || !IsController(_ownerAuth))
+                return;
+
+            if (!_isDirty && _initialSerializedDict.Matches(_dict))
                 return;
 
             SendInitialStateToServer(_dict);
@@ -624,6 +628,31 @@ namespace PurrNet
             var dict = new Dictionary<TKey, TValue>(keys.Count);
             CopyTo(dict);
             return dict;
+        }
+
+        public bool Matches(Dictionary<TKey, TValue> dict)
+        {
+            if (!isKeySerializable || !isValueSerializable)
+                return false;
+
+            int count = Mathf.Min(keys.Count, values.Count);
+
+            if (dict.Count != count)
+                return false;
+
+            for (int i = 0; i < count; i++)
+            {
+                if (keys[i] == null)
+                    return false;
+
+                if (!dict.TryGetValue(keys[i], out var value))
+                    return false;
+
+                if (!PurrEquality<TValue>.Equals(value, values[i]))
+                    return false;
+            }
+
+            return true;
         }
 
         public void CopyTo(Dictionary<TKey, TValue> dict)

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -187,9 +187,26 @@ namespace PurrNet
             _list.AddRange(_initialList);
         }
 
+        private bool MatchesInitialList()
+        {
+            if (_list.Count != _initialList.Count)
+                return false;
+
+            for (int i = 0; i < _list.Count; i++)
+            {
+                if (!PurrEquality<T>.Equals(_list[i], _initialList[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
         public override void OnSpawnSent()
         {
             if (isServer || !IsController(_ownerAuth))
+                return;
+
+            if (!_isDirty && MatchesInitialList())
                 return;
 
             SendInitialStateToServer(_list);

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -189,15 +189,27 @@ namespace PurrNet
 
         public override void OnSpawn()
         {
-            if (!IsController(_ownerAuth)) return;
-
-            if (isServer)
-                SendInitialStateToAll(_list);
-            else SendInitialStateToServer(_list);
         }
 
-        public override void OnObserverAdded(PlayerID player)
+        public override void OnSpawnSent()
         {
+            if (isServer || !IsController(_ownerAuth))
+                return;
+
+            if (!_isDirty)
+                return;
+
+            SendInitialStateToServer(_list);
+            _pendingChanges.Clear();
+            _isDirty = false;
+            _wasLastDirty = false;
+        }
+
+        public override void OnObserverAdded(PlayerID player, bool isSpawner)
+        {
+            if (isSpawner && ownerAuth && owner == player)
+                return;
+
             SendInitialToTarget(player, _list);
         }
 

--- a/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkModule/SyncList.cs
@@ -187,16 +187,9 @@ namespace PurrNet
             _list.AddRange(_initialList);
         }
 
-        public override void OnSpawn()
-        {
-        }
-
         public override void OnSpawnSent()
         {
             if (isServer || !IsController(_ownerAuth))
-                return;
-
-            if (!_isDirty)
                 return;
 
             SendInitialStateToServer(_list);


### PR DESCRIPTION
SyncVar was recently changed to send its initial state together with the spawn flow, so I decided to make SyncList and SyncDictionary work the same way.

There was an issue where non-host clients could change a collection before calling `Spawn`, but those changes would not be sent correctly to the other clients. Collection would keep its default state on the host or other clients.

This PR fixes that and also removes the delay between the object spawning and its initial sync data arriving, matching the current SyncVar behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788349053&installation_model_id=20441&pr_number=296&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F296&signature=2081ab5ca32a3be0865211d61d34cbb6dc3e2435acac306aa6b9c78841cd98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->