### PR TITLE
Prefab lookup match

### DIFF
--- a/Assets/PlayModeTests/Scripts/AssetTests/NetworkAssetsScenario.cs
+++ b/Assets/PlayModeTests/Scripts/AssetTests/NetworkAssetsScenario.cs
@@ -60,6 +60,12 @@ public class NetworkAssetsScenario : Scenario
 
     public override async UniTask<ScenarioResult> RunScenario(ScenarioContext ctx)
     {
+        if (!ctx.networkManager.prefabProvider.TryGetPrefabData(_prefab.gameObject, out var registeredData))
+            return ScenarioResult.Fail("registered prefab did not resolve by reference");
+
+        if (registeredData.prefab != _prefab.gameObject)
+            return ScenarioResult.Fail($"registered prefab resolved to `{registeredData.prefab}` instead of itself");
+
         if (ctx.isServer)
         {
             var inst = Instantiate(_prefab);

--- a/Assets/PurrNet/Runtime/Components/NetworkPrefabs/AddressableNetworkPrefabs.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkPrefabs/AddressableNetworkPrefabs.cs
@@ -40,6 +40,7 @@ namespace PurrNet
         private readonly Dictionary<int, string> _idToGuid = new();
         private readonly List<AsyncOperationHandle<GameObject>> _loadHandles = new();
         private readonly List<RuntimePrefabEntry> _runtimePrefabs = new();
+        private readonly HashSet<string> _warnedNameFallbacks = new();
         private int _runtimePrefabStartId;
 
         private struct RuntimePrefabEntry
@@ -103,7 +104,17 @@ namespace PurrNet
                 }
             }
 
-            return TryMatchByName(_prefabLookup.Values, prefab, out prefabData);
+            if (!TryMatchByName(_prefabLookup.Values, prefab, out prefabData))
+                return false;
+
+            if (_warnedNameFallbacks.Add(prefab.name))
+            {
+                PurrLogger.LogWarning(
+                    $"Resolved addressable network prefab `{prefab.name}` by name because the given reference isn't the registered one.\n" +
+                    "This happens when the same asset is duplicated across bundles; fix the Addressables group setup to avoid spawning the wrong prefab.");
+            }
+
+            return true;
         }
 
         public override void AddRuntimePrefab(string uniqueName, GameObject prefab, bool pooled = false, int warmup = 5)

--- a/Assets/PurrNet/Runtime/Components/NetworkPrefabs/NetworkPrefabs.cs
+++ b/Assets/PurrNet/Runtime/Components/NetworkPrefabs/NetworkPrefabs.cs
@@ -56,7 +56,8 @@ namespace PurrNet
                 }
             }
 
-            return TryMatchByName(this.allPrefabs, prefab, out prefabData);
+            prefabData = default;
+            return false;
         }
 
         public bool TryGetPersistentId(int prefabId, out string persistentId)

--- a/Assets/Tests/BitPacker.Tests/AddressablePrefabsLookupTests.cs
+++ b/Assets/Tests/BitPacker.Tests/AddressablePrefabsLookupTests.cs
@@ -1,0 +1,97 @@
+#if ADDRESSABLES_PURRNET_SUPPORT
+using System.Collections.Generic;
+using NUnit.Framework;
+using PurrNet;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class AddressablePrefabsLookupTests
+{
+    const string SHARED_NAME = "SharedAddressablePrefab";
+
+    readonly List<Object> _created = new();
+
+    [TearDown]
+    public void TearDown()
+    {
+        for (int i = 0; i < _created.Count; i++)
+        {
+            if (_created[i])
+                Object.DestroyImmediate(_created[i]);
+        }
+
+        _created.Clear();
+    }
+
+    AddressableNetworkPrefabs CreateProvider()
+    {
+        var provider = ScriptableObject.CreateInstance<AddressableNetworkPrefabs>();
+        _created.Add(provider);
+        return provider;
+    }
+
+    GameObject CreateNetworkedPrefab(string name)
+    {
+        var go = new GameObject(name);
+        go.AddComponent<NetworkIdentity>();
+        _created.Add(go);
+        return go;
+    }
+
+    GameObject CreatePlainPrefab(string name)
+    {
+        var go = new GameObject(name);
+        _created.Add(go);
+        return go;
+    }
+
+    [Test]
+    public void ReferenceMatchResolvesWithoutWarning()
+    {
+        var provider = CreateProvider();
+        var registered = CreateNetworkedPrefab(SHARED_NAME);
+        provider.AddRuntimePrefab("registered", registered);
+
+        Assert.That(provider.TryGetPrefabData(registered, out var data), Is.True);
+        Assert.That(data.prefab, Is.EqualTo(registered));
+    }
+
+    [Test]
+    public void BundleCopyResolvesByNameAndWarns()
+    {
+        var provider = CreateProvider();
+        var registered = CreateNetworkedPrefab(SHARED_NAME);
+        provider.AddRuntimePrefab("registered", registered);
+
+        var bundleCopy = CreateNetworkedPrefab(SHARED_NAME);
+
+        LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex(SHARED_NAME));
+
+        Assert.That(provider.TryGetPrefabData(bundleCopy, out var data), Is.True);
+        Assert.That(data.prefab, Is.EqualTo(registered));
+    }
+
+    [Test]
+    public void NonNetworkedPrefabSharingNameIsNotResolved()
+    {
+        var provider = CreateProvider();
+        provider.AddRuntimePrefab("registered", CreateNetworkedPrefab(SHARED_NAME));
+
+        var foreign = CreatePlainPrefab(SHARED_NAME);
+
+        Assert.That(provider.TryGetPrefabData(foreign, out _), Is.False);
+    }
+
+    [Test]
+    public void AmbiguousNameIsNotResolved()
+    {
+        var provider = CreateProvider();
+        provider.AddRuntimePrefab("registered-a", CreateNetworkedPrefab(SHARED_NAME));
+        provider.AddRuntimePrefab("registered-b", CreateNetworkedPrefab(SHARED_NAME));
+
+        var bundleCopy = CreateNetworkedPrefab(SHARED_NAME);
+
+        Assert.That(provider.TryGetPrefabData(bundleCopy, out _), Is.False);
+    }
+}
+#endif

--- a/Assets/Tests/BitPacker.Tests/AddressablePrefabsLookupTests.cs.meta
+++ b/Assets/Tests/BitPacker.Tests/AddressablePrefabsLookupTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 742397be1d7839a45a14fa83bb28c02e

--- a/Assets/Tests/BitPacker.Tests/BitPacker.Tests.asmdef
+++ b/Assets/Tests/BitPacker.Tests/BitPacker.Tests.asmdef
@@ -3,7 +3,9 @@
     "rootNamespace": "",
     "references": [
         "GUID:6e20f757a1bae164fa42750dd2b27dcb",
-        "GUID:e0cd26848372d4e5c891c569017e11f1"
+        "GUID:e0cd26848372d4e5c891c569017e11f1",
+        "Unity.Addressables",
+        "Unity.ResourceManager"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -25,6 +27,11 @@
             "name": "com.unity.modules.physics",
             "expression": "",
             "define": "UNITY_PHYSICS_3D"
+        },
+        {
+            "name": "com.unity.addressables",
+            "expression": "",
+            "define": "ADDRESSABLES_PURRNET_SUPPORT"
         }
     ],
     "noEngineReferences": false

--- a/Assets/Tests/BitPacker.Tests/NetworkPrefabsLookupTests.cs
+++ b/Assets/Tests/BitPacker.Tests/NetworkPrefabsLookupTests.cs
@@ -56,11 +56,26 @@ public class NetworkPrefabsLookupTests
     }
 
     [Test]
+    public void EachRegisteredPrefabResolvesToItselfDespiteSharedNames()
+    {
+        var provider = CreateProvider();
+        var first = CreateNetworkedPrefab(SHARED_NAME);
+        var second = CreateNetworkedPrefab(SHARED_NAME);
+        provider.AddRuntimePrefab("registered-a", first);
+        provider.AddRuntimePrefab("registered-b", second);
+
+        Assert.That(provider.TryGetPrefabData(first, out var firstData), Is.True);
+        Assert.That(firstData.prefab, Is.EqualTo(first));
+
+        Assert.That(provider.TryGetPrefabData(second, out var secondData), Is.True);
+        Assert.That(secondData.prefab, Is.EqualTo(second));
+    }
+
+    [Test]
     public void NonNetworkedPrefabSharingNameIsNotResolved()
     {
         var provider = CreateProvider();
-        var networked = CreateNetworkedPrefab(SHARED_NAME);
-        provider.AddRuntimePrefab("registered", networked);
+        provider.AddRuntimePrefab("registered", CreateNetworkedPrefab(SHARED_NAME));
 
         var foreign = CreatePlainPrefab(SHARED_NAME);
 
@@ -69,39 +84,10 @@ public class NetworkPrefabsLookupTests
     }
 
     [Test]
-    public void NetworkedPrefabCopySharingNameStillResolves()
-    {
-        var provider = CreateProvider();
-        var networked = CreateNetworkedPrefab(SHARED_NAME);
-        provider.AddRuntimePrefab("registered", networked);
-
-        var bundleCopy = CreateNetworkedPrefab(SHARED_NAME);
-
-        Assert.That(provider.TryGetPrefabData(bundleCopy, out var data), Is.True);
-        Assert.That(data.prefab, Is.EqualTo(networked));
-    }
-
-    [Test]
-    public void NetworkedPrefabWithDifferentIdentityCountIsNotResolved()
-    {
-        var provider = CreateProvider();
-        var networked = CreateNetworkedPrefab(SHARED_NAME);
-        provider.AddRuntimePrefab("registered", networked);
-
-        var unrelated = CreateNetworkedPrefab(SHARED_NAME);
-        var child = new GameObject("Nested");
-        child.AddComponent<NetworkIdentity>();
-        child.transform.SetParent(unrelated.transform);
-
-        Assert.That(provider.TryGetPrefabData(unrelated, out _), Is.False);
-    }
-
-    [Test]
     public void UnregisteredNetworkedPrefabSharingNameIsNotResolved()
     {
         var provider = CreateProvider();
-        var registered = CreateNetworkedPrefab(SHARED_NAME);
-        provider.AddRuntimePrefab("registered", registered);
+        provider.AddRuntimePrefab("registered", CreateNetworkedPrefab(SHARED_NAME));
 
         var unrelated = CreateNetworkedPrefab(SHARED_NAME);
 
@@ -110,29 +96,24 @@ public class NetworkPrefabsLookupTests
     }
 
     [Test]
-    public void BundleCopyResolvesEvenWhenAnotherPrefabSharesTheName()
+    public void IdenticalUnregisteredCopyIsNotResolved()
     {
         var provider = CreateProvider();
-        var registeredA = CreateNetworkedPrefab(SHARED_NAME);
-        var registeredB = CreateNetworkedPrefab(SHARED_NAME);
-        provider.AddRuntimePrefab("registered-a", registeredA);
-        provider.AddRuntimePrefab("registered-b", registeredB);
+        provider.AddRuntimePrefab("registered", CreateNetworkedPrefab(SHARED_NAME));
 
-        var bundleCopyOfA = CreateNetworkedPrefab(SHARED_NAME);
+        var copy = CreateNetworkedPrefab(SHARED_NAME);
 
-        Assert.That(provider.TryGetPrefabData(bundleCopyOfA, out var data), Is.True);
-        Assert.That(data.prefab, Is.EqualTo(registeredA));
+        Assert.That(provider.TryGetPrefabData(copy, out _), Is.False);
     }
 
     [Test]
-    public void AmbiguousNameIsNotResolved()
+    public void UnregisteredPrefabIsNotResolvedWhenNothingShareItsName()
     {
         var provider = CreateProvider();
-        provider.AddRuntimePrefab("registered-a", CreateNetworkedPrefab(SHARED_NAME));
-        provider.AddRuntimePrefab("registered-b", CreateNetworkedPrefab(SHARED_NAME));
+        provider.AddRuntimePrefab("registered", CreateNetworkedPrefab(SHARED_NAME));
 
-        var bundleCopy = CreateNetworkedPrefab(SHARED_NAME);
+        var unrelated = CreateNetworkedPrefab("SomethingElse");
 
-        Assert.That(provider.TryGetPrefabData(bundleCopy, out _), Is.False);
+        Assert.That(provider.TryGetPrefabData(unrelated, out _), Is.False);
     }
 }


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrNet/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788443772&installation_model_id=20441&pr_number=297&repository=PurrNet%2FPurrNet&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrNet%2Fpull%2F297&signature=2bf5d58b579928ee9dea844845c5e2611c666e83445fb4247230db0764d9623b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->